### PR TITLE
Use the specific version of `@commonshost/server`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "cross-env-shell lerna exec -- rollup -c=`pwd`/rollup.config.js",
     "build:prod": "cross-env PRODUCTION=true npm run build",
     "watch": "cross-env-shell lerna exec --parallel -- rollup -w -c=`pwd`/rollup.config.js",
-    "server": "npx @commonshost/server start --watch",
+    "server": "npx @commonshost/server@6.9.0 start --watch",
     "storybook": "start-storybook -p 9009 -s ./static",
     "storybook:build": "build-storybook -s ./static -o .out",
     "happo": "happo",


### PR DESCRIPTION
Use the specific version of `@commonshost/server` to fix the `Cannot find module 'node-fetch'` issue on start which caused by their new release `6.10.0` 