### PR TITLE
Force the file card to fit the container

### DIFF
--- a/packages/components/file-card/src/file-card.css
+++ b/packages/components/file-card/src/file-card.css
@@ -1,6 +1,7 @@
 :host {
 	display: block;
 	margin-bottom: var(--ts-unit-half);
+	width: 100%;
 }
 
 .file-icon-wrapper {


### PR DESCRIPTION
Before this the file card would get more space than parent in the `full` size based on the filename.
Now it fits the parent container