### PR TITLE
Add compatible Tradeshift-ui version to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ or
 
 ## ➤ Polyfills
 
-For supporting IE11 you need to add couple of things
+For supporting IE11 you need to do couple of more things
+
+- If you are using the [Tradeshift-ui](https://github.com/Tradeshift/tradeshift-ui) you need to upgrade it to a compatible version:
+
+  - For version `12` you should upgrade to `12.2.9` or newer version
+  - For version `11` you should upgrade to `11.3.2` or newer version
 
 - Don't shim CSS Custom Properties in IE11
 


### PR DESCRIPTION
There was an issue with older versions of the `tradeshift-ui` and `elements` in IE11 which was fixed by this:
>Fix the issue with web components inside ie11 When we used ts-ui and elements at the same time in ie11 it caused this error: Invalid Calling Object This will stop the web component crashing and not being able to be added after loading the ts-ui ([616bd6f](https://github.com/Tradeshift/tradeshift-ui/commit/616bd6fbcc2b9f44b2e918ba97941d8058b57b2b))
