### PR TITLE
Added es6 modules to build config.

### DIFF
--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -4,6 +4,7 @@
   "src": "src/aside.js",
   "main": "lib/aside.umd.js",
   "browser": "lib/aside.umd.js",
+  "module": "lib/aside.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -4,12 +4,12 @@
   "src": "src/button-group.js",
   "main": "lib/button-group.umd.js",
   "browser": "lib/button-group.umd.js",
+  "module": "lib/button-group.esm.js",
   "files": [
     "lib/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.5.0",
-    "@tradeshift/elements.button": "^0.5.0"
+    "@tradeshift/elements": "^0.5.0"
   },
   "gitHead": "e88391ca0cd629eac27ed1ca70ccdb64c1b31b7a"
 }

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -4,11 +4,13 @@
   "src": "src/button.js",
   "main": "lib/button.umd.js",
   "browser": "lib/button.umd.js",
+  "module": "lib/button.esm.js",
   "files": [
     "lib/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.5.0"
+    "@tradeshift/elements": "^0.5.0",
+    "@tradeshift/elements.icon": "^0.5.0"
   },
   "gitHead": "e88391ca0cd629eac27ed1ca70ccdb64c1b31b7a"
 }

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -4,6 +4,7 @@
   "src": "src/card.js",
   "main": "lib/card.umd.js",
   "browser": "lib/card.umd.js",
+  "module": "lib/card.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -4,10 +4,11 @@
   "src": "src/checkbox.js",
   "main": "lib/checkbox.umd.js",
   "browser": "lib/checkbox.umd.js",
+  "module": "lib/checkbox.esm.js",
   "files": [
     "lib/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.4.5"
+    "@tradeshift/elements": "^0.5.0"
   }
 }

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -4,6 +4,7 @@
   "src": "src/cover.js",
   "main": "lib/cover.umd.js",
   "browser": "lib/cover.umd.js",
+  "module": "lib/cover.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -4,6 +4,7 @@
   "src": "src/file-card.js",
   "main": "lib/file-card.umd.js",
   "browser": "lib/file-card.umd.js",
+  "module": "lib/file-card.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -4,6 +4,7 @@
   "src": "src/file-size.js",
   "main": "lib/file-size.umd.js",
   "browser": "lib/file-size.umd.js",
+  "module": "lib/file-size.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -4,6 +4,7 @@
   "src": "src/file-uploader-input.js",
   "main": "lib/file-uploader-input.umd.js",
   "browser": "lib/file-uploader-input.umd.js",
+  "module": "lib/file-uploader-input.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/file-uploader-input/src/file-uploader-input.js
+++ b/packages/components/file-uploader-input/src/file-uploader-input.js
@@ -4,6 +4,7 @@ import css from './file-uploader-input.css';
 import { messages, selectors, classNames, customEventNames, slotNames, sizes } from './utils';
 
 import '@tradeshift/elements.help-text';
+import '@tradeshift/elements.icon';
 
 customElementDefineHelper(
 	'ts-file-uploader-input',

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -4,6 +4,7 @@
   "src": "src/help-text.js",
   "main": "lib/help-text.umd.js",
   "browser": "lib/help-text.umd.js",
+  "module": "lib/help-text.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/icon/package-lock.json
+++ b/packages/components/icon/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tradeshift/elements.button",
+  "name": "@tradeshift/elements.icon",
   "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -53,14 +53,6 @@
           "resolved": "https://registry.npmjs.org/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.1.tgz",
           "integrity": "sha512-7Ua2c3FvqAuiC2++gIoStG9r0B5sxleq8B7o0XKuIM052amWPTaCka0UMvnQRRJEsdGgRGIUv6sLkOyfhcr1dw=="
         }
-      }
-    },
-    "@tradeshift/elements.icon": {
-      "version": "0.5.0",
-      "resolved": "https://npm.tradeshift.net/repository/npm-all/@tradeshift/elements.icon/-/elements.icon-0.5.0.tgz",
-      "integrity": "sha512-eG6jC0rWwjLnQ3aVlR2sBzbjdlmU3jffCwy2bkY1l0Nwiqq0mAaSAIaWxCYcrmOcMJXFy7dMZgMbw3u/7HLfpg==",
-      "requires": {
-        "@tradeshift/elements": "^0.5.0"
       }
     }
   }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -4,6 +4,7 @@
   "src": "src/icon.js",
   "main": "lib/icon.umd.js",
   "browser": "lib/icon.umd.js",
+  "module": "lib/icon.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -4,6 +4,7 @@
   "src": "src/list-item.js",
   "main": "lib/list-item.umd.js",
   "browser": "lib/list-item.umd.js",
+  "module": "lib/list-item.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -4,6 +4,7 @@
   "src": "src/note.js",
   "main": "lib/note.umd.js",
   "browser": "lib/note.umd.js",
+  "module": "lib/note.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/note/src/note.js
+++ b/packages/components/note/src/note.js
@@ -1,4 +1,5 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import '@tradeshift/elements.button';
 import '@tradeshift/elements.icon';
 
 import { classNames, types, customEventNames } from './utils';

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -4,6 +4,7 @@
   "src": "src/progress-bar.js",
   "main": "lib/progress-bar.umd.js",
   "browser": "lib/progress-bar.umd.js",
+  "module": "lib/progress-bar.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -4,6 +4,7 @@
   "src": "src/root.js",
   "main": "lib/root.umd.js",
   "browser": "lib/root.umd.js",
+  "module": "lib/root.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -4,6 +4,7 @@
   "src": "src/search.js",
   "main": "lib/search.umd.js",
   "browser": "lib/search.umd.js",
+  "module": "lib/search.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -4,6 +4,7 @@
   "src": "src/spinner.js",
   "main": "lib/spinner.umd.js",
   "browser": "lib/spinner.umd.js",
+  "module": "lib/spinner.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/spinner/src/spinner.js
+++ b/packages/components/spinner/src/spinner.js
@@ -1,5 +1,4 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
-import '@tradeshift/elements.cover';
 import css from './spinner.css';
 import { sizes, colors } from './utils';
 

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -4,6 +4,7 @@
   "src": "src/tooltip.js",
   "main": "lib/tooltip.umd.js",
   "browser": "lib/tooltip.umd.js",
+  "module": "lib/tooltip.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -4,6 +4,7 @@
   "src": "src/typography.js",
   "main": "lib/typography.umd.js",
   "browser": "lib/typography.umd.js",
+  "module": "lib/typography.esm.js",
   "files": [
     "lib/*"
   ],

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,5 +1,51 @@
 {
   "name": "@tradeshift/elements",
-  "version": "0.1.0",
-  "lockfileVersion": 1
+  "version": "0.5.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bundled-es-modules/url-polyfill": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/url-polyfill/-/url-polyfill-1.1.4.tgz",
+      "integrity": "sha512-sq6SN6XpHzBPE5B6Up5UFxCDr3iuREmBd8gXast9h3JUgA0tKxta6VxIA0dnkOpyT34VyIxDiIwWpsrp382cnw=="
+    },
+    "@open-wc/polyfills-loader": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/polyfills-loader/-/polyfills-loader-0.3.2.tgz",
+      "integrity": "sha512-q90Bb5cA6p9xSX8SZBsPfaHTEU2XdRi7/NFnTfiBt8qHrZK2ZcIMvXHXjX43UyF5d9xkGaffYBb7OqIkd8YypQ==",
+      "requires": {
+        "@bundled-es-modules/url-polyfill": "^1.1.3",
+        "@webcomponents/custom-elements": "^1.2.1",
+        "@webcomponents/shadycss": "^1.8.0",
+        "@webcomponents/shadydom": "^1.4.2",
+        "@webcomponents/template": "^1.4.0",
+        "@webcomponents/webcomponents-platform": "^1.0.0"
+      }
+    },
+    "@webcomponents/custom-elements": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.2.4.tgz",
+      "integrity": "sha512-WiTlgz6/kuwajYIcgyq64rSlCtb2AvbxwwrExP3wr6rKbJ72I3hi/sb4KdGUumfC+isDn2F0btZGk4MnWpyO1Q=="
+    },
+    "@webcomponents/shadycss": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
+      "integrity": "sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ=="
+    },
+    "@webcomponents/shadydom": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadydom/-/shadydom-1.6.0.tgz",
+      "integrity": "sha512-2r9SGHv13MS488ZwYXd2W123bXn/ZjWo5/pO4s9FOZmpEYv8ALWRc4VazmiFNl+3n4Cdu0uvCwju4V6ivgZKXA=="
+    },
+    "@webcomponents/template": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-HJfhAxCD+DZmtm8oCALtvyOL9JlisSDqwE/4FWfaxq4SK3gUIp/2eUjLE6zqt9n6VHeo1zQjMTOA4fKKF6qSQg=="
+    },
+    "@webcomponents/webcomponents-platform": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.1.tgz",
+      "integrity": "sha512-7Ua2c3FvqAuiC2++gIoStG9r0B5sxleq8B7o0XKuIM052amWPTaCka0UMvnQRRJEsdGgRGIUv6sLkOyfhcr1dw=="
+    }
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "src": "src/core.js",
   "main": "lib/core.umd.js",
   "browser": "lib/core.umd.js",
+  "module": "lib/core.esm.js",
   "files": [
     "lib/*",
     "src/*"

--- a/plop-templates/components/{{kebabCase name}}/package.json
+++ b/plop-templates/components/{{kebabCase name}}/package.json
@@ -4,6 +4,7 @@
   "src": "src/{{kebabCase name}}.js",
   "main": "lib/{{kebabCase name}}.umd.js",
   "browser": "lib/{{kebabCase name}}.umd.js",
+  "module": "lib/{{kebabCase name}}.esm.js",
   "files": [
     "lib/*"
   ],


### PR DESCRIPTION
Added the additional rollup config to build ES6 module for each component.
In this format all dependencies are not included in the result file of component, so the size of each component is smaller and duplicated components in the third-party applications will be loaded only once.
I built a small example with several elements and created two bundles:

with UMD modules(current master):
![umd modules](https://user-images.githubusercontent.com/55530374/68141833-8ebf7000-ff2e-11e9-8d98-f660a187379f.png)

with es6 modules(this PR):
![es6 modules](https://user-images.githubusercontent.com/55530374/68141858-9ed74f80-ff2e-11e9-86d7-f8a7573ad170.png)