### PR TITLE
Fixed broken rtl checkbox for note story

### DIFF
--- a/packages/components/note/stories/note.stories.js
+++ b/packages/components/note/stories/note.stories.js
@@ -19,13 +19,13 @@ storiesOf('ts-note', module)
 			null
 		);
 
-		const rtl = boolean('RTL', false);
+		const dir = boolean('RTL', false) ? 'rtl' : 'ltr';
 		const icon = select('Icon', Object.keys(icons), Object.keys(icons)[0]);
 		const hidden = boolean('Hidden', false);
 		const content = text('Content', 'Sample text for note');
 
 		return html`
-			<ts-note type="${type}" ?rtl="${rtl}" icon="${icon}" ?hidden="${hidden}">
+			<ts-note type="${type}" dir="${dir}" icon="${icon}" ?hidden="${hidden}">
 				${content}
 			</ts-note>
 		`;


### PR DESCRIPTION
RTL checkbox in the [ts-note storybook](https://tradeshift.github.io/elements/?path=/story/ts-note--default) **didn't change component direction on click**. 

I suggest the problem is in the usage of outdated RTL property in the 'ts-note' storybook. Property 'rtl' was changed to 'dir' in note component, but the storybook code was not updated. 

Fixed using dir property.  


 