### PR TITLE
Add close on escape press for aside/modal component

### DIFF
--- a/packages/components/aside/src/aside.js
+++ b/packages/components/aside/src/aside.js
@@ -1,4 +1,4 @@
-import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import { TSElement, unsafeCSS, html, customElementDefineHelper, CloseOnEscBehavior } from '@tradeshift/elements';
 import css from './aside.css';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.cover';
@@ -18,6 +18,7 @@ customElementDefineHelper(
 				title: { type: String, attribute: 'data-title' },
 				visible: { type: Boolean, attribute: 'data-visible', reflect: true },
 				busy: { type: String, attribute: 'data-busy', reflect: true },
+				noCloseOnEscKey: { type: Boolean, attribute: 'no-close-on-esc-key' },
 				hasFoot: { type: Boolean },
 				hasPlatformObject: { type: Boolean }
 			};
@@ -29,6 +30,8 @@ customElementDefineHelper(
 			this.visible = false;
 			this.hasFoot = false;
 			this.hasPlatformObject = false;
+			this.noCloseOnEscKey = false;
+			this.closeBehavior = new CloseOnEscBehavior(this);
 		}
 
 		close(e) {
@@ -116,6 +119,15 @@ customElementDefineHelper(
 					this.dispatchCustomEvent(customEventNames.CLOSED);
 				}
 			}
+		}
+
+		firstUpdated() {
+			this.closeBehavior.start();
+		}
+
+		disconnectedCallback() {
+			super.disconnectedCallback();
+			this.closeBehavior.stop();
 		}
 	}
 );

--- a/packages/components/modal/src/modal.js
+++ b/packages/components/modal/src/modal.js
@@ -1,4 +1,4 @@
-import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import { TSElement, unsafeCSS, html, customElementDefineHelper, CloseOnEscBehavior } from '@tradeshift/elements';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.cover';
 import '@tradeshift/elements.header';
@@ -17,7 +17,8 @@ customElementDefineHelper(
 				dir: { type: String, reflect: true, attribute: 'data-dir' },
 				size: { type: String, reflect: true, attribute: 'data-size' },
 				title: { type: String, reflect: true, attribute: 'data-title' },
-				visible: { type: Boolean, reflect: true, attribute: 'data-visible' }
+				visible: { type: Boolean, reflect: true, attribute: 'data-visible' },
+				noCloseOnEscKey: { type: Boolean, attribute: 'no-close-on-esc-key' }
 			};
 		}
 
@@ -25,6 +26,8 @@ customElementDefineHelper(
 			super();
 			this.size = sizes.LARGE;
 			this.title = '';
+			this.noCloseOnEscKey = false;
+			this.closeBehavior = new CloseOnEscBehavior(this);
 		}
 
 		get direction() {
@@ -80,6 +83,15 @@ customElementDefineHelper(
 				</div>
 				<ts-cover class="ts-dialog-cover" ?data-visible=${this.visible} @click="${this.close}"></ts-cover>
 			`;
+		}
+
+		firstUpdated() {
+			this.closeBehavior.start();
+		}
+
+		disconnectedCallback() {
+			this.closeBehavior.stop();
+			super.disconnectedCallback();
 		}
 	}
 );

--- a/packages/core/src/core.js
+++ b/packages/core/src/core.js
@@ -1,7 +1,7 @@
 import { LitElement, unsafeCSS } from 'lit-element';
 import commonCSS from './common.css';
 import { constants } from './utils';
-export { constants, helpers } from './utils';
+export { constants, helpers, CloseOnEscBehavior } from './utils';
 
 export function customElementDefineHelper(name, component) {
 	if (!window.customElements.get(name)) {

--- a/packages/core/src/utils/behaviors.js
+++ b/packages/core/src/utils/behaviors.js
@@ -1,0 +1,28 @@
+import { isEscapeKeyEvent } from './helper-functions';
+
+export class CloseOnEscBehavior {
+	constructor(parentElement) {
+		this.parentElement = parentElement;
+		this.onKeyDown = this.onKeyDown.bind(this);
+	}
+
+	start() {
+		document.addEventListener('keydown', this.onKeyDown);
+	}
+
+	stop() {
+		document.removeEventListener('keydown', this.onKeyDown);
+	}
+
+	onKeyDown(event) {
+		if (
+			!this.parentElement.visible ||
+			this.parentElement.noCloseOnEscKey ||
+			event.isComposing ||
+			!isEscapeKeyEvent(event)
+		) {
+			return;
+		}
+		this.parentElement.close();
+	}
+}

--- a/packages/core/src/utils/constants.js
+++ b/packages/core/src/utils/constants.js
@@ -35,3 +35,11 @@ export const delay = {
 	FAST: 200,
 	SLOW: 600
 };
+
+export const keyboardEventKeys = {
+	ESCAPE: 'Escape'
+};
+
+export const keyboardEventKeyCodes = {
+	ESCAPE: 27
+};

--- a/packages/core/src/utils/helper-functions.js
+++ b/packages/core/src/utils/helper-functions.js
@@ -1,3 +1,5 @@
+import { keyboardEventKeys, keyboardEventKeyCodes } from './constants';
+
 export const classNamesToSelector = classNamesObject => {
 	const selectors = {};
 
@@ -21,3 +23,7 @@ export const debounceEvent = (callback, wait) => {
 		timeout = setTimeout(() => callback.apply(this, args), wait);
 	};
 };
+
+// Keycode check for IE11
+export const isEscapeKeyEvent = event =>
+	event.key === keyboardEventKeys.ESCAPE || event.keyCode === keyboardEventKeyCodes.ESCAPE;

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -1,5 +1,7 @@
 import * as constantsData from './constants';
 import * as helperFunctions from './helper-functions';
+import { CloseOnEscBehavior as closeBehavior } from './behaviors';
 
 export const constants = constantsData;
 export const helpers = helperFunctions;
+export const CloseOnEscBehavior = closeBehavior;


### PR DESCRIPTION
### Closing components on `ESC` press
[This issue](https://github.com/Tradeshift/elements/issues/158) asks to make aside/modal behavior on `ESC` press **the same** as users have with tradeshift-ui.

- Pressing `ESC` closes **all opened** asides/modals (not only the top one)
- Closing with `ESC` shortcut works even if **input currently focused**.

#### Also added

- Possibility to turn off `ESC` shortcut with _no-close-on-esc-key_ boolean attribute
- While IME composition is active, `ESC` is used for stopping the composition, so we won't close the panel on the press of it. 

#### Suggestion for future

Maybe there is a better way to do it is as it was done in the _polymer_ overlay component - _iron-overlay-behavior_. To have some behavior **shared between components** that track all opened asides/modals and can close on `ESC` the last one.