### PR TITLE
NAV-61 action-button component

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,56 +109,6 @@
 			</article>
 
 			<article>
-				<h2>ts-action-button</h2>
-				<div class="button-container">
-					<div class="box">
-						<div>
-							<ts-action-button icon="download">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button icon="download" dir="rtl">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button icon="download"></ts-action-button>
-						</div>
-					</div>
-					<div class="box">
-						<div>
-							<ts-action-button type="gray" icon="download">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="gray" icon="download" dir="rtl">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="gray" icon="download"></ts-action-button>
-						</div>
-					</div>
-					<div class="box">
-						<div>
-							<ts-action-button type="blue" icon="download">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="blue" icon="download" dir="rtl">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="blue" icon="download"></ts-action-button>
-						</div>
-					</div>
-					<div style="background-color: #28354F;" class="box">
-						<div>
-							<ts-action-button type="inverted" icon="download">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="inverted" icon="download" dir="rtl">Action Button</ts-action-button>
-						</div>
-						<div>
-							<ts-action-button type="inverted" icon="download"></ts-action-button>
-						</div>
-					</div>
-				</div>
-			</article>
-
-			<article>
 				<h2>Document Card</h2>
 				<div class="document-card-container">
 					<ts-document-card
@@ -732,6 +682,50 @@
 						</div>
 						<div>
 							<ts-button type="danger" icon="download"></ts-button>
+						</div>
+					</div>
+				</div>
+			</article>
+
+			<article>
+				<h2>ts-action-button</h2>
+				<div class="button-container">
+					<div class="box">
+						<div>
+							<ts-action-button icon="download" title="Action button"></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button icon="download" dir="rtl" title="Action button"></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button icon="download"></ts-action-button>
+						</div>
+					</div>
+					<div class="box">
+						<div>
+							<ts-action-button type="action-blue" icon="download" title="Action button"></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="action-blue" icon="download" dir="rtl" title="Action button"></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="action-blue" icon="download"></ts-action-button>
+						</div>
+					</div>
+					<div style="background-color: #28354F;" class="box">
+						<div>
+							<ts-action-button type="action-inverted" icon="download" title="Action button"></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button
+								type="action-inverted"
+								icon="download"
+								dir="rtl"
+								title="Action button"
+							></ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="action-inverted" icon="download"></ts-action-button>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
 						'icon',
 						'aside',
 						'button',
+						'action-button',
 						'button-group',
 						'card',
 						'checkbox',
@@ -104,6 +105,56 @@
 					<ts-status class="grid-status" status="note" text="custom note message"></ts-status>
 					<ts-status class="grid-status" status="note" text="LTR شسيشسي"></ts-status>
 					<ts-status class="grid-status" dir="rtl" status="note" text="RTL شسيشسي"></ts-status>
+				</div>
+			</article>
+
+			<article>
+				<h2>ts-action-button</h2>
+				<div class="button-container">
+					<div class="box">
+						<div>
+							<ts-action-button icon="download">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button icon="download" dir="rtl">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button icon="download"></ts-action-button>
+						</div>
+					</div>
+					<div class="box">
+						<div>
+							<ts-action-button type="gray" icon="download">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="gray" icon="download" dir="rtl">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="gray" icon="download"></ts-action-button>
+						</div>
+					</div>
+					<div class="box">
+						<div>
+							<ts-action-button type="blue" icon="download">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="blue" icon="download" dir="rtl">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="blue" icon="download"></ts-action-button>
+						</div>
+					</div>
+					<div style="background-color: #28354F;" class="box">
+						<div>
+							<ts-action-button type="inverted" icon="download">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="inverted" icon="download" dir="rtl">Action Button</ts-action-button>
+						</div>
+						<div>
+							<ts-action-button type="inverted" icon="download"></ts-action-button>
+						</div>
+					</div>
 				</div>
 			</article>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
-      "integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
+        "@babel/generator": "^7.7.7",
         "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.5",
+        "@babel/parser": "^7.7.7",
         "@babel/template": "^7.7.4",
         "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4",
@@ -35,9 +35,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.7.4",
@@ -285,9 +285,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -332,9 +332,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
-      "integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
+      "integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -352,9 +352,9 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
-      "integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+      "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -489,9 +489,9 @@
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
-      "integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+      "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -627,9 +627,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
-      "integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+      "integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.7.4",
@@ -732,9 +732,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.7.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
-      "integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
+      "integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -742,9 +742,9 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
         "@babel/plugin-proposal-dynamic-import": "^7.7.4",
         "@babel/plugin-proposal-json-strings": "^7.7.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
         "@babel/plugin-syntax-async-generators": "^7.7.4",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
         "@babel/plugin-syntax-json-strings": "^7.7.4",
@@ -758,7 +758,7 @@
         "@babel/plugin-transform-classes": "^7.7.4",
         "@babel/plugin-transform-computed-properties": "^7.7.4",
         "@babel/plugin-transform-destructuring": "^7.7.4",
-        "@babel/plugin-transform-dotall-regex": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.7",
         "@babel/plugin-transform-duplicate-keys": "^7.7.4",
         "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
         "@babel/plugin-transform-for-of": "^7.7.4",
@@ -772,7 +772,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
         "@babel/plugin-transform-new-target": "^7.7.4",
         "@babel/plugin-transform-object-super": "^7.7.4",
-        "@babel/plugin-transform-parameters": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.7",
         "@babel/plugin-transform-property-literals": "^7.7.4",
         "@babel/plugin-transform-regenerator": "^7.7.5",
         "@babel/plugin-transform-reserved-words": "^7.7.4",
@@ -784,16 +784,16 @@
         "@babel/plugin-transform-unicode-regex": "^7.7.4",
         "@babel/types": "^7.7.4",
         "browserslist": "^4.6.0",
-        "core-js-compat": "^3.4.7",
+        "core-js-compat": "^3.6.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.7.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
-      "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -4894,9 +4894,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.18.tgz",
-          "integrity": "sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==",
+          "version": "12.12.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
+          "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
           "dev": true
         }
       }
@@ -5643,62 +5643,69 @@
         "lit-element": "^2.2.1"
       }
     },
+    "@tradeshift/elements.action-button": {
+      "version": "file:packages/components/action-button",
+      "requires": {
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3"
+      }
+    },
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.button": "^0.7.2",
-        "@tradeshift/elements.cover": "^0.7.2",
-        "@tradeshift/elements.spinner": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.button": "^0.7.3",
+        "@tradeshift/elements.cover": "^0.7.3",
+        "@tradeshift/elements.spinner": "^0.7.3"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       },
       "dependencies": {
         "@tradeshift/elements": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.2.tgz",
-          "integrity": "sha512-06uOom82o787+0C6i6etENPaUzHZ9d+jm5PF8Pd5r4noHbEvI28n2c7mKPUIsrrwpIEqFE2ESuTH3kZM5PtLuQ==",
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.3.tgz",
+          "integrity": "sha512-UC+ImcwPF+3MpjaWg3zcRdrJreaaSI5Yynlj1/bHtEb8/iIfzfZPUDTcgbfx72PiqLDSGgpDvV0FsYZ4Tg6E5Q==",
           "requires": {
             "lit-element": "^2.2.1"
           }
@@ -5708,110 +5715,110 @@
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.card": "^0.7.2",
-        "@tradeshift/elements.file-size": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2",
-        "@tradeshift/elements.progress-bar": "^0.7.2",
-        "@tradeshift/elements.typography": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.card": "^0.7.3",
+        "@tradeshift/elements.file-size": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3",
+        "@tradeshift/elements.progress-bar": "^0.7.3",
+        "@tradeshift/elements.typography": "^0.7.3"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.typography": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.typography": "^0.7.3"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.help-text": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2",
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.help-text": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3",
         "lit-html": "^1.1.1"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.app-icon": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.app-icon": "^0.7.3"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2",
-        "@tradeshift/elements.typography": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3",
+        "@tradeshift/elements.typography": "^0.7.3"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.button": "^0.7.2",
-        "@tradeshift/elements.cover": "^0.7.2",
-        "@tradeshift/elements.header": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.button": "^0.7.3",
+        "@tradeshift/elements.cover": "^0.7.3",
+        "@tradeshift/elements.header": "^0.7.3"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.button": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.button": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       },
       "dependencies": {
         "@tradeshift/elements": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.2.tgz",
-          "integrity": "sha512-06uOom82o787+0C6i6etENPaUzHZ9d+jm5PF8Pd5r4noHbEvI28n2c7mKPUIsrrwpIEqFE2ESuTH3kZM5PtLuQ==",
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.3.tgz",
+          "integrity": "sha512-UC+ImcwPF+3MpjaWg3zcRdrJreaaSI5Yynlj1/bHtEb8/iIfzfZPUDTcgbfx72PiqLDSGgpDvV0FsYZ4Tg6E5Q==",
           "requires": {
             "lit-element": "^2.2.1"
           }
@@ -5821,19 +5828,19 @@
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       },
       "dependencies": {
         "@tradeshift/elements": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.2.tgz",
-          "integrity": "sha512-06uOom82o787+0C6i6etENPaUzHZ9d+jm5PF8Pd5r4noHbEvI28n2c7mKPUIsrrwpIEqFE2ESuTH3kZM5PtLuQ==",
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@tradeshift/elements/-/elements-0.7.3.tgz",
+          "integrity": "sha512-UC+ImcwPF+3MpjaWg3zcRdrJreaaSI5Yynlj1/bHtEb8/iIfzfZPUDTcgbfx72PiqLDSGgpDvV0FsYZ4Tg6E5Q==",
           "requires": {
             "lit-element": "^2.2.1"
           }
@@ -5843,21 +5850,21 @@
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.7.2",
-        "@tradeshift/elements.icon": "^0.7.2",
-        "@tradeshift/elements.typography": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3",
+        "@tradeshift/elements.icon": "^0.7.3",
+        "@tradeshift/elements.typography": "^0.7.3"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.7.2"
+        "@tradeshift/elements": "^0.7.3"
       }
     },
     "@types/babel__core": {
@@ -6029,9 +6036,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.16.tgz",
-      "integrity": "sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==",
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -10098,19 +10105,19 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
-      "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
+      "integrity": "sha512-Z3eCNjGgoYluH89Jt4wVkfYsc/VdLrA2/woX5lm0isO/pCT+P+Y+o65bOuEnjDJLthdwTBxbCVzptTXtc18fJg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.8.2",
-        "semver": "^6.3.0"
+        "semver": "7.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
       }
@@ -11503,9 +11510,9 @@
       "dev": true
     },
     "dotenv-defaults": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz",
-      "integrity": "sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.0.3.tgz",
+      "integrity": "sha512-EHeXF8VZA/XhkGJCtRpJCTHC8GkoisPXjdvJMzxgFrlN6lTEW/eksRNsVKnW0BxR1pGZH8IEBO/D0mDkIrC6fA==",
       "dev": true,
       "requires": {
         "dotenv": "^6.2.0"
@@ -16723,9 +16730,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-ci": {
@@ -16761,9 +16768,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-decimal": {
@@ -16891,9 +16898,9 @@
       }
     },
     "is-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.0.tgz",
-      "integrity": "sha512-ptj+FffEGJN9hLuakga2S3mYQt5PVN+w7+fL3SAgxKhlCePSt24Q3fiSozhvphbwCQ0+QPA1rJnLSoS2LnbCVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
       "dev": true
     },
     "is-module": {
@@ -17035,9 +17042,9 @@
       "dev": true
     },
     "is-set": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.0.tgz",
-      "integrity": "sha512-So5/xwRDzU3X7kOt2vpvrsj/Asx5E7Q5IyX6itksB96FJgyydSe9tFwfCq7IZ8URDS4h45FhNgfENToTgBfmgw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
       "dev": true
     },
     "is-ssh": {
@@ -17056,9 +17063,9 @@
       "dev": true
     },
     "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-svg": {
@@ -21514,9 +21521,9 @@
           }
         },
         "core-js": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-          "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
+          "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==",
           "dev": true
         },
         "del": {
@@ -21755,9 +21762,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
-      "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.43.tgz",
+      "integrity": "sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -26236,9 +26243,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -28247,9 +28254,9 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -28257,9 +28264,9 @@
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -29136,9 +29143,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
     },
     "uglify-js": {
@@ -29688,9 +29695,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
-      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
+      "version": "4.41.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.4.tgz",
+      "integrity": "sha512-Lc+2uB6NjpCWsHI3trkoISOI64h9QYIXenbEWj3bn3oyjfB1lEBXjWAfAyY2sM0rZn41oD5V91OLwKRwS6Wp8Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -30536,13 +30543,12 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
-      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "util.promisify": "~1.0.0",
         "xmlbuilder": "~11.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@tradeshift/elements.app-icon": "file:packages/components/app-icon",
     "@tradeshift/elements.aside": "file:packages/components/aside",
     "@tradeshift/elements.button": "file:packages/components/button",
+    "@tradeshift/elements.action-button": "file:packages/components/action-button",
     "@tradeshift/elements.button-group": "file:packages/components/button-group",
     "@tradeshift/elements.card": "file:packages/components/card",
     "@tradeshift/elements.checkbox": "file:packages/components/checkbox",

--- a/packages/components/action-button/README.md
+++ b/packages/components/action-button/README.md
@@ -25,6 +25,20 @@
 		</a>
 </p>
 
+<style>
+table {
+    width:100%;
+}
+</style>
+
+## ➤ Properties
+
+| Property | Attribute | Type   | Default       | Description              |
+| -------- | --------- | ------ | ------------- | ------------------------ |
+| type     | type      | string | 'action-gray' | Style of the button      |
+| icon     | icon      | string | ''            | Icon on button, required |
+| title    | title     | string | ''            | Text on button, optional |
+
 ## ➤ How to use it
 
 - Install the package of actionButton

--- a/packages/components/action-button/README.md
+++ b/packages/components/action-button/README.md
@@ -1,0 +1,131 @@
+<h1 align="center">
+    <a href="https://tradeshift.com/">
+      <img alt="Tradeshift" src="https://tradeshift.com/wp-content/themes/Tradeshift/img/brand/logo-black.png"/>
+    </a>
+</h1>
+
+<h1 align="center">Elements - action-button</h1>
+
+<p align="center">
+  Part of the reusable Tradeshift UI Components as Web Components.
+    <a href="https://tradeshift.github.io/elements/?path=/story/ts-action-button--default">
+      Demo
+    </a>
+</p>
+
+<p align="center">
+    <a href="https://www.npmjs.com/package/@tradeshift/elements.action-button">
+      <img alt="NPM Version" src="https://badgen.net/npm/v/@tradeshift/elements.action-button" height="20"/>
+    </a>
+    <a href="https://npmcharts.com/compare/@tradeshift/elements.action-button?minimal=true">
+		  <img alt="Downloads per month" src="https://badgen.net/npm/dm/@tradeshift/elements.action-button" height="20"/>
+		</a>
+		<a href="https://www.npmjs.com/browse/depended/@tradeshift/elements.action-button">
+		  <img alt="Dependent packages" src="https://badgen.net/npm/dependents/@tradeshift/elements.action-button" height="20"/>
+		</a>
+</p>
+
+## ➤ How to use it
+
+- Install the package of actionButton
+
+```shell
+$ npm i @tradeshift/elements.action-button --save
+```
+
+- Import the component
+
+```js
+import '@tradeshift/elements.action-button';
+```
+
+or
+
+```html
+<script src="node_modules/@tradeshift/elements.action-button/lib/action-button.umd.js"></script>
+```
+
+- Use it like [demo]("https://tradeshift.github.io/elements/?path=/story/ts-action-button--default")
+
+- Our components rely on having the `Open Sans` available, You can see the `font-weight` and `font-style` you need to load [here](https://github.com/Tradeshift/elements/blob/master/packages/core/src/fonts.css), or you can just load it from our package (for now)
+
+```html
+<link rel="stylesheet" href="node_modules/@tradeshift/elements/src/fonts.css" />
+```
+
+## ➤ Polyfills
+
+For supporting IE11 you need to add couple of things
+
+- Don't shim CSS Custom Properties in IE11
+
+```html
+<!-- Place this in the <head>, before the Web Component polyfills are loaded -->
+<script>
+	if (!window.Promise) {
+		window.ShadyCSS = { nativeCss: true };
+	}
+</script>
+```
+
+##### You have two options for polyfills library:
+
+1. Use [`@open-wc/polyfills-loader`](https://github.com/open-wc/open-wc/tree/master/packages/polyfills-loader)
+
+- Installation
+
+```shell
+$ npm i @open-wc/polyfills-loader
+```
+
+- Load it
+
+```js
+import loadPolyfills from '@open-wc/polyfills-loader';
+
+loadPolyfills().then(() => import('./my-app.js'));
+```
+
+2. Use [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs)
+
+- Installation
+
+```hell
+$ npm i @webcomponents/webcomponentsjs --save
+```
+
+- Enable ES5 class-less Custom Elements
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+```
+
+- Load appropriate polyfills and shims with [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/webcomponentsjs)
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+```
+
+## ➤ How to contribute
+
+Thanks for your interest and help!
+
+- First thing you need to do is read this [[Component Checklist](https://github.com/Tradeshift/elements/wiki/Component-checklist)] which contains lots of important information about what you need to consider when you are creating/changing components
+
+##### [General info](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter)
+
+You can find some [links to useful materials](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter) about what we are using and some tutorials and articles that can help you get started.
+
+## ➤ [Polyfill Limitations](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+You can see a list of limitations that we should watch out for, [here](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+## ➤ License
+
+- You can always create forks on GitHub, submit Issues and Pull Requests.
+- You can only use Tradeshift Elements to make apps on a Tradeshift platform, e.g. tradeshift.com.
+- You can fix a bug until the bugfix is deployed by Tradeshift.
+- You can host Tradeshift Elements yourself.
+- If you want to make a bigger change or just want to talk with us, reach out to our team here on GitHub.
+
+You can read the full license agreement in the [LICENSE.md](https://github.com/Tradeshift/elements/blob/master/LICENSE.md).

--- a/packages/components/action-button/package.json
+++ b/packages/components/action-button/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tradeshift/elements.action-button",
+  "version": "0.7.3",
+  "src": "src/action-button.js",
+  "main": "lib/action-button.umd.js",
+  "browser": "lib/action-button.umd.js",
+  "module": "lib/action-button.esm.js",
+  "files": [
+    "lib/*"
+  ],
+  "dependencies": {
+    "@tradeshift/elements": "^0.7.3",
+    "@tradeshift/elements.icon": "^0.7.3"
+  }
+}

--- a/packages/components/action-button/src/action-button.css
+++ b/packages/components/action-button/src/action-button.css
@@ -1,0 +1,94 @@
+/* General........................................................ */
+
+:host {
+	display: inline-block;
+	font-size: var(--ts-font-size-default);
+	line-height: var(--ts-unit);
+
+	& > button {
+		position: relative;
+		min-width: var(--ts-unit-double);
+		border: none;
+		font-size: var(--ts-font-size-default);
+
+		background: transparent;
+		border-radius: 4px;
+		padding: var(--ts-unit-half);
+		display: flex;
+		align-items: center;
+
+		&:hover {
+			background: var(--ts-color-gray-lightest);
+			color: var(--ts-color-blue-darkest);
+		}
+
+		&:focus {
+			color: var(--ts-color-blue-darkest);
+			background: var(--ts-color-gray-lightest);
+			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-gray);
+		}
+
+		& span {
+			display: block;
+			line-height: var(--ts-unit);
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+
+			color: var(--ts-color-blue-darkest);
+			padding: 0 var(--ts-unit-quarter);
+			font-weight: var(--ts-fontweight);
+			text-transform: none;
+			letter-spacing: normal;
+		}
+	}
+}
+
+/* Blue type......................................................*/
+
+:host([type='blue']) {
+	& > button {
+		& span {
+			color: var(--ts-color-blue);
+		}
+
+		&:hover {
+			& span {
+				color: var(--ts-color-blue);
+			}
+		}
+
+		&:focus {
+			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
+			& span {
+				color: var(--ts-color-blue);
+			}
+		}
+	}
+}
+
+/* Inverted type......................................................*/
+
+:host([type='inverted']) {
+	& > button {
+		box-shadow: none;
+
+		& span {
+			color: var(--ts-color-white);
+		}
+
+		&:hover {
+			background: var(--action-button-inverted-hover);
+			& span {
+				color: var(--ts-color-white);
+			}
+		}
+
+		&:focus {
+			background: var(--action-button-inverted-hover);
+			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
+			& span {
+				color: var(--ts-color-white);
+			}
+		}
+	}
+}

--- a/packages/components/action-button/src/action-button.css
+++ b/packages/components/action-button/src/action-button.css
@@ -45,7 +45,7 @@
 
 /* Blue type......................................................*/
 
-:host([type='blue']) {
+:host([type='action-blue']) {
 	& > button {
 		& span {
 			color: var(--ts-color-blue);
@@ -68,7 +68,7 @@
 
 /* Inverted type......................................................*/
 
-:host([type='inverted']) {
+:host([type='action-inverted']) {
 	& > button {
 		box-shadow: none;
 

--- a/packages/components/action-button/src/action-button.js
+++ b/packages/components/action-button/src/action-button.js
@@ -1,0 +1,54 @@
+import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import '@tradeshift/elements.icon';
+import css from './action-button.css';
+import { actionTypeToIconType, types } from './utils';
+
+customElementDefineHelper(
+	'ts-action-button',
+	class extends TSElement {
+		static get styles() {
+			return [TSElement.styles, unsafeCSS(css)];
+		}
+
+		static get properties() {
+			return {
+				type: { type: String, reflect: true },
+				title: { type: String, reflect: true },
+				icon: { type: String, reflect: true },
+				dir: { type: String }
+			};
+		}
+
+		get iconType() {
+			if (!this.type) {
+				return actionTypeToIconType[types.gray];
+			}
+			return actionTypeToIconType[this.type];
+		}
+
+		get direction() {
+			return this.dir ? this.dir : this.bodyDir;
+		}
+
+		get actionTitle() {
+			if (!this.title) {
+				return;
+			}
+
+			return html`
+				<span>
+					${this.title}
+				</span>
+			`;
+		}
+
+		render() {
+			return html`
+				<button ?disabled="${this.disabled}" dir="${this.direction}">
+					<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
+					${this.actionTitle}
+				</button>
+			`;
+		}
+	}
+);

--- a/packages/components/action-button/src/action-button.js
+++ b/packages/components/action-button/src/action-button.js
@@ -1,7 +1,7 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
 import '@tradeshift/elements.icon';
 import css from './action-button.css';
-import { actionTypeToIconType, types } from './utils';
+import { types } from './utils';
 
 customElementDefineHelper(
 	'ts-action-button',
@@ -15,15 +15,13 @@ customElementDefineHelper(
 				type: { type: String, reflect: true },
 				title: { type: String, reflect: true },
 				icon: { type: String, reflect: true },
-				dir: { type: String }
+				dir: { type: String, reflect: true }
 			};
 		}
 
-		get iconType() {
-			if (!this.type) {
-				return actionTypeToIconType[types.gray];
-			}
-			return actionTypeToIconType[this.type];
+		constructor() {
+			super();
+			this.type = types.ACTION_GRAY;
 		}
 
 		get direction() {
@@ -45,7 +43,7 @@ customElementDefineHelper(
 		render() {
 			return html`
 				<button ?disabled="${this.disabled}" dir="${this.direction}">
-					<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
+					<ts-icon icon="${this.icon}" size="large" type="${this.type}"></ts-icon>
 					${this.actionTitle}
 				</button>
 			`;

--- a/packages/components/action-button/src/utils/constants.js
+++ b/packages/components/action-button/src/utils/constants.js
@@ -1,11 +1,5 @@
 export const types = {
-	gray: 'gray',
-	blue: 'blue',
-	inverted: 'inverted'
-};
-
-export const actionTypeToIconType = {
-	gray: 'action-gray',
-	blue: 'action-blue',
-	inverted: 'action-inverted'
+	ACTION_GRAY: 'action-gray',
+	ACTION_BLUE: 'action-blue',
+	ACTION_INVERTED: 'action-inverted'
 };

--- a/packages/components/action-button/src/utils/constants.js
+++ b/packages/components/action-button/src/utils/constants.js
@@ -1,0 +1,11 @@
+export const types = {
+	gray: 'gray',
+	blue: 'blue',
+	inverted: 'inverted'
+};
+
+export const actionTypeToIconType = {
+	gray: 'action-gray',
+	blue: 'action-blue',
+	inverted: 'action-inverted'
+};

--- a/packages/components/action-button/src/utils/index.js
+++ b/packages/components/action-button/src/utils/index.js
@@ -1,1 +1,1 @@
-export { actionTypeToIconType, types } from './constants';
+export { types } from './constants';

--- a/packages/components/action-button/src/utils/index.js
+++ b/packages/components/action-button/src/utils/index.js
@@ -1,0 +1,1 @@
+export { actionTypeToIconType, types } from './constants';

--- a/packages/components/action-button/stories/action-button.happo.js
+++ b/packages/components/action-button/stories/action-button.happo.js
@@ -1,0 +1,24 @@
+import { storiesOf } from '@open-wc/demoing-storybook';
+import '@tradeshift/elements';
+import '@tradeshift/elements.action-button';
+
+import { createHappoStories } from '../../../../.storybook-happo/utils';
+import { types } from '../src/utils';
+
+storiesOf('ts-action-button', module).add('test', () => {
+	const properties = {
+		icon: { download: 'download' },
+		dir: { rtl: 'rtl' },
+		type: types
+	};
+
+	const options = {
+		columns: 5,
+		persistent_props: {
+			icon: 'download',
+			title: 'Support'
+		}
+	};
+
+	return createHappoStories('action-button', properties, '', options);
+});

--- a/packages/components/action-button/stories/action-button.stories.js
+++ b/packages/components/action-button/stories/action-button.stories.js
@@ -1,0 +1,33 @@
+import { storiesOf, html } from '@open-wc/demoing-storybook';
+import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
+
+import { helpers } from '@tradeshift/elements';
+import '@tradeshift/elements.action-button';
+
+import { types } from '../src/utils';
+import icons from '../../icon/src/assets/icons';
+
+storiesOf('ts-action-button', module)
+	.addDecorator(withKnobs)
+	.add('default', () => {
+		const title = text('title', 'Action');
+
+		const type = select(
+			'Type',
+			{
+				default: '',
+				...helpers.objectKeysChangeCase(types)
+			},
+			''
+		);
+
+		const dir = boolean('RTL', false) ? 'rtl' : 'ltr';
+		const icon = select('Icon', Object.keys(icons), 'download');
+		const color = type === types.inverted ? '#28354F' : '#FFFFFF';
+
+		return html`
+			<div style="background-color: ${color}; padding: 20px;">
+				<ts-action-button type="${type}" icon="${icon}" title="${title}" dir="${dir}"> </ts-action-button>
+			</div>
+		`;
+	});

--- a/packages/components/action-button/stories/action-button.stories.js
+++ b/packages/components/action-button/stories/action-button.stories.js
@@ -23,7 +23,7 @@ storiesOf('ts-action-button', module)
 
 		const dir = boolean('RTL', false) ? 'rtl' : 'ltr';
 		const icon = select('Icon', Object.keys(icons), 'download');
-		const color = type === types.inverted ? '#28354F' : '#FFFFFF';
+		const color = type === types.ACTION_INVERTED ? '#28354F' : '#FFFFFF';
 
 		return html`
 			<div style="background-color: ${color}; padding: 20px;">

--- a/packages/components/icon/src/icon.css
+++ b/packages/components/icon/src/icon.css
@@ -102,6 +102,18 @@ svg {
 	color: var(--ts-color-slate-lightest);
 }
 
+:host([type='action-gray']) svg {
+	color: var(--ts-color-gray-darker);
+}
+
+:host([type='action-blue']) svg {
+	color: var(--ts-color-blue);
+}
+
+:host([type='action-inverted']) svg {
+	color: var(--ts-color-white);
+}
+
 :host([circular]) {
 	border-radius: 50%;
 	background-color: var(--ts-icon-color);

--- a/packages/components/icon/src/utils/constants.js
+++ b/packages/components/icon/src/utils/constants.js
@@ -16,7 +16,10 @@ export const types = {
 	DISABLED: 'disabled',
 	DISABLED_CHECKED: 'disabled-checked',
 	SUGGESTED: 'suggested',
-	SLATE_LIGHTEST: 'slate-lightest'
+	SLATE_LIGHTEST: 'slate-lightest',
+	ACTION_GRAY: 'action-gray',
+	ACTION_BLUE: 'action-blue',
+	ACTION_INVERTED: 'action-inverted'
 };
 
 export const typeColors = {
@@ -33,7 +36,10 @@ export const typeColors = {
 	[types.DISABLED]: colors.GRAY + colorModifiers.LIGHTER,
 	[types.SUGGESTED]: colors.PURPLE,
 	[types.DISABLED_CHECKED]: colors.GRAY + colorModifiers.LIGHT,
-	[types.SLATE_LIGHTEST]: colors.SLATE + colorModifiers.LIGHTEST
+	[types.SLATE_LIGHTEST]: colors.SLATE + colorModifiers.LIGHTEST,
+	[types.ACTION_GRAY]: colors.GRAY + colorModifiers.DARKER,
+	[types.ACTION_BLUE]: colors.BLUE,
+	[types.ACTION_INVERTED]: colors.WHITE
 };
 
 export const sizes = {

--- a/packages/core/src/vars.css
+++ b/packages/core/src/vars.css
@@ -89,6 +89,7 @@
 	--ts-color-blue: rgb(0, 174, 255);
 	--ts-color-blue-dark: rgb(0, 133, 204);
 	--ts-color-blue-darker: rgb(0, 101, 163);
+	--ts-color-blue-darkest: rgb(40, 53, 79);
 	/* Purple */
 	--ts-color-purple-lightest: rgb(236, 216, 238);
 	--ts-color-purple-lighter: rgb(218, 176, 221);
@@ -169,6 +170,9 @@
 	--spinner-color-blue: var(--ts-color-blue);
 	--spinner-color-mono: var(--ts-color-slate-lightest);
 	--spinner-color-white: var(--ts-color-white);
+
+	/* Action button........................................................ */
+	--action-button-inverted-hover: rgb(57, 75, 104);
 }
 
 ts-root {

--- a/rollup.globals.json
+++ b/rollup.globals.json
@@ -1,5 +1,6 @@
 {
 	"@tradeshift/elements": "ts.elements",
+	"@tradeshift/elements.action-button": "ts.elements.action-button",
 	"@tradeshift/elements.app-icon": "ts.elements.app-icon",
 	"@tradeshift/elements.aside": "ts.elements.aside",
 	"@tradeshift/elements.button": "ts.elements.button",


### PR DESCRIPTION
At first, I tried to add action-button styles to the standard _ts-button_ component. It looks like, It's better do not create extra components, where you can use a generic button. You can have a look at it in _kolombet/action-button_ branch. It didn't work well because:

- Action button has variants (gray, blue, dark-bg), which doesn't fit _ts-button_ API. It looks like a bad idea to create type property for each action button style and duplicate almost all styles for it.
- We could use base style (type=text for example) and additional modifiers (like color=gray/blue/etc) which override some styles from the base type. But it not so good to have API looks like `<ts-button type="text" color="blue"/>` which mislead. It looks like just a blue text button, not button with an icon and blue border and background. Also, it requires to change public API.
- The ts-button becomes too generic and has too many extra modifiers (busy, disabled, size, color, icon), which allows creating button states which are not approved by design guidelines. 

We discussed this problem and come up with idea to make a separate component for the action button: _ts-action-button_. 
It uses _title_ property, instead of using **slots**, to check if we have any text inside, to add some **paddings** to the _span_. We can't use `:empty` or `:blank` selector on the _span_, because it contains a slot. And we can't use `:slotted()` selector, it doesn't work with text nodes. And it's not so good to make it possible to pass anything to the slot, where we want only text node.

Features:
- It supports **RTL**
- Possible value in type property: **gray, blue, inverted**
- Default style: **gray**

Additional:
- example in index.html
- storybook
- happo