### PR TITLE
Nested tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,6 +412,29 @@
 						</p>
 					</ts-tab>
 				</ts-tabs>
+
+				<h2>Nested tabs</h2>
+
+				<ts-tabs dir="ltr">
+					<ts-tab label="First">
+						<div id="tab1">
+							<ts-tabs dir="rtl">
+								<ts-tab label="Nested1"></ts-tab>
+								<ts-tab label="Nested2"></ts-tab>
+								<ts-tab label="Nested3"></ts-tab>
+							</ts-tabs>
+						</div>
+					</ts-tab>
+					<ts-tab label="Second">
+						<div id="tab2">
+							<ts-tabs dir="ltr">
+								<ts-tab label="Nested4"></ts-tab>
+								<ts-tab label="Nested5"></ts-tab>
+								<ts-tab label="Nested6"></ts-tab>
+							</ts-tabs>
+						</div>
+					</ts-tab>
+				</ts-tabs>
 			</article>
 
 			<article>

--- a/packages/components/tabs/src/tabs.js
+++ b/packages/components/tabs/src/tabs.js
@@ -98,9 +98,21 @@ customElementDefineHelper(
 			this.generateHeaderTabs();
 		}
 
+		onTabPropChange(e) {
+			// stop event bubbling to prevent any parent tabs from switch
+			if (e) {
+				e.stopImmediatePropagation();
+			}
+			this.generateHeaderTabs();
+		}
+
 		firstUpdated() {
 			// listen to prop change on ts-tab and rerender the tabs header
-			this.shadowRoot.host.addEventListener('tab-prop-change', this.generateHeaderTabs);
+			this.shadowRoot.host.addEventListener('tab-prop-change', this.onTabPropChange);
+		}
+
+		disconnectedCallback() {
+			this.shadowRoot.host.removeEventListener('tab-prop-change', this.onTabPropChange);
 		}
 
 		render() {

--- a/packages/components/tabs/src/tabs.js
+++ b/packages/components/tabs/src/tabs.js
@@ -28,7 +28,7 @@ customElementDefineHelper(
 		}
 
 		tabClickHandler(tab, index) {
-			const tabs = this.shadowRoot.host.querySelectorAll('ts-tab');
+			const tabs = this.directChildrenTabs;
 			for (let i = 0; i < tabs.length; ++i) {
 				const curTab = tabs[i];
 				const wasSelected = curTab.getAttribute('selected');
@@ -79,9 +79,13 @@ customElementDefineHelper(
 			/* eslint-enable */
 		}
 
+		get directChildrenTabs() {
+			const tabs = Array.from(this.shadowRoot.host.querySelectorAll('ts-tab'));
+			return tabs.filter(tab => tab.parentNode === this);
+		}
+
 		generateHeaderTabs() {
-			const slottedTabs = this.shadowRoot.host.querySelectorAll('ts-tab');
-			this.tabs = Array.from(slottedTabs).map(tabNode => {
+			this.tabs = this.directChildrenTabs.map(tabNode => {
 				return {
 					label: tabNode.getAttribute('label'),
 					icon: tabNode.getAttribute('icon'),


### PR DESCRIPTION
Prevented _event propagation_ from nested tabs to their parents. Stopped _event bubbling_ after first event handling, to prevent any parent tabs from the catching tab switching event from children _tabs_ components
I suppose I found another bug with nested tabs - a parent should query only **direct** children, not all nested ones, so I added direct children getter helper - `directChildrenTabs`.
Added to _index.html_ example of nested tabs.

![Screenshot 2019-12-19 at 17 15 57](https://user-images.githubusercontent.com/58551256/71189576-54622600-2283-11ea-899d-8d74fe47e353.png)

![Screenshot 2019-12-19 at 17 17 25](https://user-images.githubusercontent.com/58551256/71189659-778cd580-2283-11ea-8d0d-ea5eaa1b6778.png)

