### PR TITLE
NAV-61 action button style for ts-button component

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
 				document.body.appendChild(coreEl);
 				coreEl.onload = function() {
 					var components = [
+						'button',
+						'button-group',
 						'root',
 						'list-item',
 						'tooltip',
 						'typography',
 						'icon',
 						'aside',
-						'button',
-						'button-group',
 						'card',
 						'checkbox',
 						'cover',
@@ -653,6 +653,9 @@
 						</div>
 						<div>
 							<ts-button type="text" size="micro">Text Button</ts-button>
+						</div>
+						<div>
+							<ts-button type="text" icon="download">Text Button</ts-button>
 						</div>
 					</div>
 					<div class="box">

--- a/packages/components/button/src/button.css
+++ b/packages/components/button/src/button.css
@@ -23,6 +23,7 @@
 		line-height: var(--ts-unit);
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+		white-space: nowrap;
 	}
 }
 
@@ -177,6 +178,36 @@
 	}
 }
 
+/* Text + icon type (action).....................................................*/
+
+:host([type='text'][icon]) {
+	& > button {
+		padding: var(--ts-unit-half);
+		& span {
+			color: var(--ts-color-blue-darkest);
+		}
+	}
+}
+
+:host(:not([busy])[type='text'][icon]) {
+	& > button {
+		&:hover {
+			background: var(--ts-color-gray-lightest);
+			& span {
+				color: var(--ts-color-blue-darkest);
+			}
+		}
+
+		&:focus {
+			background: var(--ts-color-gray-lightest);
+			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-gray);
+			& span {
+				color: var(--ts-color-blue-darkest);
+			}
+		}
+	}
+}
+
 /* Micro size......................................................*/
 
 :host(:not([type='text'])[size='micro']) {
@@ -218,6 +249,10 @@
 		left: 50%;
 		top: 50%;
 		transform: translate(-50%, -50%);
+	}
+
+	& span {
+		display: none;
 	}
 }
 

--- a/packages/components/button/src/button.css
+++ b/packages/components/button/src/button.css
@@ -146,6 +146,8 @@
 	& > button {
 		background: transparent;
 		border-radius: var(--ts-radius);
+		display: flex;
+		align-items: center;
 	}
 
 	& span {
@@ -205,7 +207,7 @@
 
 /* Button with an icon ............................................*/
 
-:host([icon]) {
+:host(:not([type='text'])[icon]) {
 	& > button {
 		width: var(--ts-unit-double);
 		height: var(--ts-unit-double);

--- a/packages/components/button/src/button.js
+++ b/packages/components/button/src/button.js
@@ -30,12 +30,24 @@ export class TSButton extends TSElement {
 		return colorBackgroundTypes.indexOf(this.type) > -1 ? 'inverted' : 'default';
 	}
 
+	get iconWithText() {
+		return html`
+			<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon><span><slot></slot></span>
+		`;
+	}
+
+	get normalIcon() {
+		return html`
+			<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
+		`;
+	}
+
 	render() {
 		return html`
 			<button ?disabled="${this.disabled}">
 				${this.icon
 					? html`
-							<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
+							${this.type === types.TEXT ? this.iconWithText : this.normalIcon}
 					  `
 					: html`
 							<span><slot></slot></span>

--- a/packages/components/button/src/button.js
+++ b/packages/components/button/src/button.js
@@ -9,6 +9,10 @@ export class TSButton extends TSElement {
 		return [TSElement.styles, unsafeCSS(css)];
 	}
 
+	get direction() {
+		return this.dir || this.bodyDir;
+	}
+
 	static get properties() {
 		return {
 			type: { type: String, reflect: true },
@@ -16,7 +20,8 @@ export class TSButton extends TSElement {
 			busy: { type: String, reflect: true },
 			icon: { type: String, reflect: true },
 			disabled: { type: Boolean, reflect: true },
-			grouped: { type: Boolean, reflect: true }
+			grouped: { type: Boolean, reflect: true },
+			dir: { type: String, reflect: true }
 		};
 	}
 
@@ -26,32 +31,22 @@ export class TSButton extends TSElement {
 	}
 
 	get iconType() {
+		if (this.icon && this.type === types.TEXT) {
+			return 'action';
+		}
 		const colorBackgroundTypes = [types.DANGER, types.WARNING, types.ACCEPT, types.PRIMARY];
 		return colorBackgroundTypes.indexOf(this.type) > -1 ? 'inverted' : 'default';
 	}
 
-	get iconWithText() {
-		return html`
-			<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon><span><slot></slot></span>
-		`;
-	}
-
-	get normalIcon() {
-		return html`
-			<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
-		`;
-	}
-
 	render() {
 		return html`
-			<button ?disabled="${this.disabled}">
+			<button ?disabled="${this.disabled}" dir="${this.direction}">
 				${this.icon
 					? html`
-							${this.type === types.TEXT ? this.iconWithText : this.normalIcon}
+							<ts-icon icon="${this.icon}" size="large" type="${this.iconType}"></ts-icon>
 					  `
-					: html`
-							<span><slot></slot></span>
-					  `}
+					: ''}
+				<span><slot></slot></span>
 			</button>
 		`;
 	}

--- a/packages/components/button/stories/button.stories.js
+++ b/packages/components/button/stories/button.stories.js
@@ -27,7 +27,7 @@ storiesOf('ts-button', module)
 			''
 		);
 
-		const label = text('Lable', 'Button');
+		const label = text('Label', 'Button');
 		const busy = boolean('Busy', false);
 		const disabled = boolean('Disabled', false);
 
@@ -67,5 +67,16 @@ storiesOf('ts-button', module)
 
 		return html`
 			<ts-button ?disabled="${disabled}" ?busy="${busy}" icon="${icon}" type="${type}" size="${size}"> </ts-button>
+		`;
+	})
+	.add('action', () => {
+		const label = text('Label', 'Action');
+		const icon = select('Icon', Object.keys(icons), 'download');
+		const direction = boolean('RTL', false) ? 'rtl' : 'ltr';
+
+		return html`
+			<ts-button type="text" icon="${icon}" dir="${direction}">
+				${label}
+			</ts-button>
 		`;
 	});

--- a/packages/components/icon/src/icon.css
+++ b/packages/components/icon/src/icon.css
@@ -102,6 +102,10 @@ svg {
 	color: var(--ts-color-slate-lightest);
 }
 
+:host([type='action']) svg {
+	color: var(--ts-color-gray);
+}
+
 :host([circular]) {
 	border-radius: 50%;
 	background-color: var(--ts-icon-color);

--- a/packages/components/icon/src/utils/constants.js
+++ b/packages/components/icon/src/utils/constants.js
@@ -16,7 +16,8 @@ export const types = {
 	DISABLED: 'disabled',
 	DISABLED_CHECKED: 'disabled-checked',
 	SUGGESTED: 'suggested',
-	SLATE_LIGHTEST: 'slate-lightest'
+	SLATE_LIGHTEST: 'slate-lightest',
+	ACTION: 'action'
 };
 
 export const typeColors = {
@@ -33,7 +34,8 @@ export const typeColors = {
 	[types.DISABLED]: colors.GRAY + colorModifiers.LIGHTER,
 	[types.SUGGESTED]: colors.PURPLE,
 	[types.DISABLED_CHECKED]: colors.GRAY + colorModifiers.LIGHT,
-	[types.SLATE_LIGHTEST]: colors.SLATE + colorModifiers.LIGHTEST
+	[types.SLATE_LIGHTEST]: colors.SLATE + colorModifiers.LIGHTEST,
+	[types.ACTION]: colors.GRAY
 };
 
 export const sizes = {

--- a/packages/components/icon/stories/icon.stories.js
+++ b/packages/components/icon/stories/icon.stories.js
@@ -8,7 +8,7 @@ import icons from '../src/assets/icons';
 
 storiesOf('ts-icon', module)
 	.addDecorator(withKnobs)
-	.add('type"', () => {
+	.add('type', () => {
 		const size = select('Size', helpers.objectKeysChangeCase(sizes), sizes.MEDIUM);
 
 		const type = select('Type', helpers.objectKeysChangeCase(types), types.DEFAULT);


### PR DESCRIPTION
Made simple action button implementation **inside** _ts-button_.
Currently, we need only default _gray_ state. It's implemented as `type="text"` button with the icon specified. 

Normal:
![Screenshot 2020-01-07 at 16 59 03](https://user-images.githubusercontent.com/58551256/71908935-30ea1700-316f-11ea-8561-8874a5d5f8e0.png)

Hover:
![Screenshot 2020-01-07 at 16 58 55](https://user-images.githubusercontent.com/58551256/71908946-347d9e00-316f-11ea-8467-1169fcce2528.png)

Pressed:
![Screenshot 2020-01-07 at 16 58 59](https://user-images.githubusercontent.com/58551256/71908950-36476180-316f-11ea-9dd8-6287bc189472.png)