### PR TITLE
Improved support of IE11 in table and index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Tradeshift Elements v0.5</title>
+		<title>Tradeshift Elements v0.7</title>
 
 		<!-- Don't shim CSS Custom Properties on IE11 -->
 		<script>
@@ -162,7 +162,7 @@
 							property: 'context',
 							size: 'large',
 							value: 'Context',
-							renderFunction(item, row) {
+							renderFunction: function(item, row) {
 								const card = document.createElement('ts-document-card');
 								card.name = item.name;
 								card.description = item.description;
@@ -177,7 +177,7 @@
 							size: 'small',
 							value: 'Type',
 							display: 'left',
-							renderFunction(item) {
+							renderFunction: function(item) {
 								const div = document.createElement('div');
 								div.style.display = 'flex';
 								div.style.justifyContent = 'flex-start';
@@ -193,7 +193,7 @@
 							visibility: 'desktop-only',
 							property: 'newActivity',
 							value: 'New Activity',
-							renderFunction(item, row) {
+							renderFunction: function(item, row) {
 								const div = document.createElement('div');
 								div.innerText = item;
 								if (row.mobileLastActivity.unread > 0) {
@@ -214,7 +214,7 @@
 							property: 'mobileLastActivity',
 							size: 'small',
 							display: 'right',
-							renderFunction(item) {
+							renderFunction: function(item) {
 								const div = document.createElement('div');
 								div.style.paddingRight = '10px';
 								div.style.whiteSpace = 'nowrap';

--- a/packages/components/table/src/table.js
+++ b/packages/components/table/src/table.js
@@ -56,7 +56,9 @@ customElementDefineHelper(
 		}
 
 		getVisibilityClass(visibility) {
-			return [VISIBILITY.ALWAYS_VISIBLE, VISIBILITY.DESKTOP_ONLY, VISIBILITY.MOBILE_ONLY].includes(visibility)
+			return [VISIBILITY.ALWAYS_VISIBLE, VISIBILITY.DESKTOP_ONLY, VISIBILITY.MOBILE_ONLY].some(
+				vis => vis === visibility
+			)
 				? visibility
 				: VISIBILITY.ALWAYS_VISIBLE;
 		}


### PR DESCRIPTION
Replaced `Array.prototype.includes()` by `Array.prototype.some()` to natively support IE11.
Also removed the shorthand functions in object literals, which are not supported by IE11.