### PR TITLE
list-item accepts slot for ts-app-icon

### DIFF
--- a/packages/components/list-item/src/list-item.css
+++ b/packages/components/list-item/src/list-item.css
@@ -40,6 +40,10 @@ button {
 	padding-right: var(--ts-unit-half);
 }
 
+:host([no-wrap]) .text-wrapper {
+	overflow: hidden;
+}
+
 :host([selected]) {
 	& button {
 		background: var(--ts-color-blue);

--- a/packages/components/list-item/src/list-item.js
+++ b/packages/components/list-item/src/list-item.js
@@ -1,4 +1,4 @@
-import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import { TSElement, unsafeCSS, html, customElementDefineHelper, validateSlottedNodes } from '@tradeshift/elements';
 import css from './list-item.css';
 
 import '@tradeshift/elements.typography';
@@ -21,8 +21,13 @@ customElementDefineHelper(
 				dir: { type: String, reflect: true },
 				icon: { type: String, reflect: true },
 				iconLeft: { type: String, attribute: 'icon-left', reflect: true },
-				iconRight: { type: String, attribute: 'icon-right', reflect: true }
+				iconRight: { type: String, attribute: 'icon-right', reflect: true },
+				noWrap: { type: Boolean, attribute: 'no-wrap' }
 			};
+		}
+		constructor() {
+			super();
+			this.hasSlottedIcon = false;
 		}
 
 		get direction() {
@@ -37,13 +42,26 @@ customElementDefineHelper(
 			return colorType;
 		}
 
+		slotChangeHandler(e) {
+			this.hasSlottedIcon = true;
+			const slottedNodes = e.currentTarget.assignedNodes();
+			validateSlottedNodes(this.tagName, slottedNodes, ['TS-APP-ICON']);
+			this.requestUpdate();
+		}
+
 		get iconLeftTemplate() {
 			const icon = this.icon || this.iconLeft;
-			if (icon) {
-				return html`
-					<ts-icon class="icon-left" icon="${icon}" size="large" type="${this.colorType}"></ts-icon>
-				`;
-			}
+			const slotClass = this.hasSlottedIcon ? 'icon-left' : '';
+
+			return icon
+				? html`
+						<ts-icon class="icon-left" icon="${icon}" size="large" type="${this.colorType}"></ts-icon>
+				  `
+				: html`
+						<span class="${slotClass}">
+							<slot name="icon-left" @slotchange="${this.slotChangeHandler}"></slot>
+						</span>
+				  `;
 		}
 
 		get iconRightTemplate() {
@@ -61,7 +79,12 @@ customElementDefineHelper(
 					<ts-typography variant="title" type="${this.colorType}" text="${this.title}"></ts-typography>
 					${this.subtitle
 						? html`
-								<ts-typography variant="subtitle" type="${this.colorType}" text="${this.subtitle}"></ts-typography>
+								<ts-typography
+									variant="subtitle"
+									type="${this.colorType}"
+									text="${this.subtitle}"
+									?no-wrap="${this.noWrap}"
+								></ts-typography>
 						  `
 						: null}
 				</div>

--- a/packages/components/list-item/stories/list-item.happo.js
+++ b/packages/components/list-item/stories/list-item.happo.js
@@ -1,24 +1,48 @@
 import { storiesOf } from '@open-wc/demoing-storybook';
 import '@tradeshift/elements';
 import '@tradeshift/elements.list-item';
+import '@tradeshift/elements.app-icon';
 
 import { createHappoStories } from '../../../../.storybook-happo/utils';
+import icon from '../../../../static/icon.svg';
 
-storiesOf('ts-list-item', module).add('test', () => {
-	const properties = {
-		dir: { rtl: 'rtl' },
-		disabled: { true: true },
-		selected: { true: true },
-		icon: { 'arrow-up': 'arrow-up' }
-	};
+storiesOf('ts-list-item', module)
+	.add('test', () => {
+		const properties = {
+			dir: { rtl: 'rtl' },
+			disabled: { true: true },
+			selected: { true: true },
+			noWrap: { true: true },
+			subtitle: { shortText: 'Subtitle sample text' },
+			icon: { 'arrow-up': 'arrow-up' }
+		};
 
-	const options = {
-		columns: 5,
-		persistent_props: {
-			title: 'Title sample text',
-			subtitle: 'Subtitle sample text',
-			selectable: { true: true }
-		}
-	};
-	return createHappoStories('list-item', properties, '', options);
-});
+		const options = {
+			columns: 5,
+			persistent_props: {
+				title: 'Title sample text',
+				subtitle: 'Subtitle sample text some long subtitle that should illustrate wrap',
+				selectable: { true: true }
+			}
+		};
+		return createHappoStories('list-item', properties, '', options);
+	})
+	.add('test with slot', () => {
+		const properties = {
+			dir: { rtl: 'rtl' },
+			disabled: { true: true },
+			selected: { true: true }
+		};
+
+		const options = {
+			columns: 5,
+			persistent_props: {
+				title: 'Title sample text',
+				subtitle: 'Subtitle sample text',
+				selectable: { true: true }
+			}
+		};
+		const slot = `<ts-app-icon slot="icon-left" src=${icon}></ts-app-icon>`;
+
+		return createHappoStories('list-item', properties, slot, options);
+	});

--- a/packages/components/list-item/stories/list-item.stories.js
+++ b/packages/components/list-item/stories/list-item.stories.js
@@ -2,8 +2,10 @@ import { storiesOf, html } from '@open-wc/demoing-storybook';
 import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
 
 import '@tradeshift/elements.list-item';
+import '@tradeshift/elements.app-icon';
 
 import icons from '../../icon/src/assets/icons';
+import appIcon from '../../../../static/icon.svg';
 
 storiesOf('ts-list-item', module)
 	.addDecorator(withKnobs)
@@ -11,6 +13,7 @@ storiesOf('ts-list-item', module)
 		const selectable = boolean('selectable', true);
 		const disabled = boolean('disabled', false);
 		const selected = boolean('selected', false);
+		const noWrap = boolean('no-wrap', false);
 		const icon = select('icon', Object.keys(icons), Object.keys(icons)[0]);
 		const iconRight = select('icon-right', Object.keys(icons), Object.keys(icons)[1]);
 		const title = text('title', 'Title sample text');
@@ -31,10 +34,70 @@ storiesOf('ts-list-item', module)
 				?disabled="${disabled}"
 				?selectable="${selectable}"
 				?selected="${selected}"
+				?no-wrap="${noWrap}"
 				icon="${icon}"
 				icon-right="${iconRight}"
 				dir="${dir}"
 			></ts-list-item>
+		`;
+	})
+	.add('with custom icon', () => {
+		const selectable = boolean('selectable', true);
+		const disabled = boolean('disabled', false);
+		const selected = boolean('selected', false);
+		const noWrap = boolean('no-wrap', false);
+		const title = text('title', 'Title sample text');
+		const subtitle = text('subtitle', 'Subtitle sample text');
+
+		const dir = select(
+			'dir',
+			{
+				ltr: 'ltr',
+				rtl: 'rtl'
+			},
+			'ltr'
+		);
+		return html`
+			<ts-list-item
+				title=${title}
+				subtitle="${subtitle}"
+				?disabled="${disabled}"
+				?selectable="${selectable}"
+				?selected="${selected}"
+				?no-wrap="${noWrap}"
+				dir="${dir}"
+			>
+				<ts-app-icon slot="icon-left" src=${appIcon}></ts-app-icon>
+			</ts-list-item>
+		`;
+	})
+	.add('without icons', () => {
+		const selectable = boolean('selectable', true);
+		const disabled = boolean('disabled', false);
+		const selected = boolean('selected', false);
+		const noWrap = boolean('no-wrap', false);
+		const title = text('title', 'Title sample text');
+		const subtitle = text('subtitle', 'Subtitle sample text');
+
+		const dir = select(
+			'dir',
+			{
+				ltr: 'ltr',
+				rtl: 'rtl'
+			},
+			'ltr'
+		);
+		return html`
+			<ts-list-item
+				title=${title}
+				subtitle="${subtitle}"
+				?disabled="${disabled}"
+				?selectable="${selectable}"
+				?selected="${selected}"
+				?no-wrap="${noWrap}"
+				dir="${dir}"
+			>
+			</ts-list-item>
 		`;
 	})
 	.add('Menu', () => {
@@ -59,21 +122,27 @@ storiesOf('ts-list-item', module)
 		items[2].selected = true;
 		items[3].disabled = true;
 		items[4].selected = true;
+		items[4].title = text('title', 'List item without no-wrap');
+		items[4].subtitle = text('subtitle', 'This text will be displayed on 2 lines because no-wrap is not set on it');
 		items[5] = {
 			...items[5],
 			disabled: true,
 			selected: true
 		};
+		items[5].title = text('title', 'List item with no-wrap');
+		items[5].subtitle = text('subtitle', 'This text should be cutt off soon because there is not enough space');
+		items[5].noWrap = true;
 
 		function test(data) {
 			const el = document.createElement('ts-list-item');
-			el.title = `${title} ${data.id}`;
-			el.subtitle = `${subtitle} ${data.id}`;
+			el.title = `${data.title || title} ${data.id}`;
+			el.subtitle = `${data.subtitle || subtitle} ${data.id}`;
 			el.icon = icon;
 			el.iconRight = iconRight;
 			el.dir = dir;
 			el.disabled = boolean('disabled' + data.id, false);
 			el.selectable = 'true';
+			data.noWrap && el.setAttribute('no-wrap', data.noWrap);
 			el.addEventListener('click', e => {
 				if (!e.target.disabled) {
 					e.target.selected = !e.target.selected;


### PR DESCRIPTION
- Allows ts-list-item to be able to receive a ts-app-icon (as a slot) instead of the lelft icon shown in a list item.
- Added no-wrap attribute to ts-list-item, in order to truncate the subtitle after one line