### PR TITLE
fix: add repository annotation for github npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
   "bugs": {
     "url": "https://github.com/Tradeshift/elements/issues"
   },
-  "repository": "github:Tradeshift/elements.git",
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git"
+  },
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Tradeshift element Team",
   "contributors": [

--- a/packages/components/app-icon/package.json
+++ b/packages/components/app-icon/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/app-icon"
   }
 }

--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -13,5 +13,10 @@
     "@tradeshift/elements.button": "^0.12.0",
     "@tradeshift/elements.cover": "^0.12.0",
     "@tradeshift/elements.spinner": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/aside"
   }
 }

--- a/packages/components/basic-table/package.json
+++ b/packages/components/basic-table/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/basic-table"
   }
 }

--- a/packages/components/board/package.json
+++ b/packages/components/board/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/board"
   }
 }

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/button-group"
   }
 }

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -11,5 +11,10 @@
   "dependencies": {
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/button"
   }
 }

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/card"
   }
 }

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/checkbox"
   }
 }

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/cover"
   }
 }

--- a/packages/components/document-card/package.json
+++ b/packages/components/document-card/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/document-card"
   }
 }

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -15,5 +15,10 @@
     "@tradeshift/elements.icon": "^0.12.0",
     "@tradeshift/elements.progress-bar": "^0.12.0",
     "@tradeshift/elements.typography": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/file-card"
   }
 }

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -11,5 +11,10 @@
   "dependencies": {
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.typography": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/file-size"
   }
 }

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -13,5 +13,10 @@
     "@tradeshift/elements.help-text": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0",
     "lit-html": "^1.1.1"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/file-uploader-input"
   }
 }

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -11,5 +11,10 @@
   "dependencies": {
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.app-icon": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/header"
   }
 }

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -11,5 +11,10 @@
   "dependencies": {
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/help-text"
   }
 }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/icon"
   }
 }

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/input"
   }
 }

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/label"
   }
 }

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -12,5 +12,10 @@
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0",
     "@tradeshift/elements.typography": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/list-item"
   }
 }

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -13,5 +13,10 @@
     "@tradeshift/elements.button": "^0.12.0",
     "@tradeshift/elements.cover": "^0.12.0",
     "@tradeshift/elements.header": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/modal"
   }
 }

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -12,5 +12,10 @@
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.button": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/note"
   }
 }

--- a/packages/components/pager/package.json
+++ b/packages/components/pager/package.json
@@ -12,5 +12,10 @@
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0",
     "@tradeshift/elements.tooltip": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/pager"
   }
 }

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/progress-bar"
   }
 }

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -13,5 +13,10 @@
   },
   "peerDependencies": {
     "@tradeshift/elements.radio": "^0.9.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/radio-group"
   }
 }

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -9,5 +9,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/radio"
   }
 }

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/root"
   }
 }

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -11,5 +11,10 @@
   "dependencies": {
     "@tradeshift/elements": "^0.12.0",
     "@tradeshift/elements.icon": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/search"
   }
 }

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/spinner"
   }
 }

--- a/packages/components/status/package.json
+++ b/packages/components/status/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/status"
   }
 }

--- a/packages/components/tab/package.json
+++ b/packages/components/tab/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/tab"
   }
 }

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -15,5 +15,10 @@
   },
   "peerDependencies": {
     "@tradeshift/elements.tab": "^0.9.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/tabs"
   }
 }

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/tooltip"
   }
 }

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -10,5 +10,10 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.12.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/typography"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,5 +11,10 @@
   ],
   "dependencies": {
     "lit-element": "^2.2.1"
+  },
+  "repository" : {
+    "type" : "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/core"
   }
 }


### PR DESCRIPTION
In order to support syncing from npmjs.com, we need to add repository
annotations to all packages.

See https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#publishing-multiple-packages-to-the-same-repository