### PR TITLE
Fix unresponsive visible property on spinner

### DIFF
--- a/packages/components/pager/stories/pager.stories.js
+++ b/packages/components/pager/stories/pager.stories.js
@@ -19,6 +19,7 @@ storiesOf('ts-pager', module)
 
 			return html`
 				<ts-pager
+					style="position: relative; top: 50px;"
 					per-page="${perPage}"
 					total-pages="${totalPages}"
 					active-page="${activePage}"

--- a/packages/components/spinner/README.md
+++ b/packages/components/spinner/README.md
@@ -25,6 +25,15 @@
 		</a>
 </p>
 
+## ➤ Properties
+
+| Property | Attribute    | Type    | Default | Description                                     |
+| -------- | ------------ | ------- | ------- | ----------------------------------------------- |
+| visible  | data-visible | boolean | false   | Show/hide the spinner                           |
+| message  | data-message | string  | -       | Text to show below the spinner                  |
+| size     | data-size    | string  | large   | Size of the spinner, `large`, `medium`, `small` |
+| color    | data-color   | string  | blue    | Spinner color, `blue`, `mono`, `white`          |
+
 ## ➤ How to use it
 
 - Install the package of spinner

--- a/packages/components/spinner/src/spinner.js
+++ b/packages/components/spinner/src/spinner.js
@@ -5,6 +5,12 @@ import { sizes, colors } from './utils';
 customElementDefineHelper(
 	'ts-spinner',
 	class extends TSElement {
+		constructor() {
+			super();
+			this.color = colors.BLUE;
+			this.size = sizes.LARGE;
+		}
+
 		static get styles() {
 			return [TSElement.styles, unsafeCSS(css)];
 		}
@@ -12,18 +18,10 @@ customElementDefineHelper(
 		static get properties() {
 			return {
 				color: { type: String, attribute: 'data-color', reflect: true },
-				message: { type: String, attribute: 'data-message' },
+				message: { type: String, attribute: 'data-message', reflect: true },
 				size: { type: String, attribute: 'data-size', reflect: true },
-				visible: { type: Boolean, attribute: 'data-visible' }
+				visible: { type: Boolean, attribute: 'data-visible', reflect: true }
 			};
-		}
-
-		constructor() {
-			super();
-			this.color = colors.BLUE;
-			this.message = '';
-			this.size = sizes.LARGE;
-			this.visible = false;
 		}
 
 		get messageHtml() {
@@ -37,7 +35,7 @@ customElementDefineHelper(
 
 		render() {
 			if (!this.visible) {
-				return '';
+				return html``;
 			}
 			return html`
 				<div class="spinner"></div>

--- a/packages/components/spinner/stories/spinner.stories.js
+++ b/packages/components/spinner/stories/spinner.stories.js
@@ -4,6 +4,7 @@ import { helpers } from '@tradeshift/elements';
 
 import '@tradeshift/elements.spinner';
 import { sizes, colors } from '../src/utils';
+import readme from '../README.md';
 
 storiesOf('ts-spinner', module)
 	.addDecorator(withKnobs)
@@ -33,4 +34,7 @@ storiesOf('ts-spinner', module)
 			<ts-spinner ?data-visible="${visible}" data-message="${message}" data-size="${size}" data-color="${color}">
 			</ts-spinner>
 		`;
-	});
+	},
+	{ notes: readme }
+	);
+


### PR DESCRIPTION
- Fix unresponsive visible property
Based on the lit-element documentation:

  The component’s render method can return anything that lit-html can render.
Typically, it returns a single TemplateResult object
(the same type returned by the html tag function).

- Update readme file of spinner

- Add a bit of margin in storybook of pager to make tooltip visible
