### PR TITLE
Added TS typings to each element

### DIFF
--- a/packages/components/app-icon/package.json
+++ b/packages/components/app-icon/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/app-icon.umd.js",
   "module": "lib/app-icon.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/app-icon.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/app-icon/types/app-icon.d.ts
+++ b/packages/components/app-icon/types/app-icon.d.ts
@@ -1,0 +1,5 @@
+export declare class TSIcon {
+	size?: '' | 'large';
+	src?: string;
+	alt?: string;
+}

--- a/packages/components/app-icon/types/utils/constants.d.ts
+++ b/packages/components/app-icon/types/utils/constants.d.ts
@@ -1,0 +1,3 @@
+export namespace sizes {
+    export const LARGE: string;
+}

--- a/packages/components/app-icon/types/utils/index.d.ts
+++ b/packages/components/app-icon/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { sizes } from "./constants";

--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/aside.umd.js",
   "module": "lib/aside.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/aside.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.button": "^0.13.0",

--- a/packages/components/aside/types/aside.d.ts
+++ b/packages/components/aside/types/aside.d.ts
@@ -1,0 +1,9 @@
+export declare class TSAside {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	'data-title'?: string;
+	'data-visible'?: boolean;
+	'data-busy'?: string;
+	'no-close-on-esc-key'?: boolean;
+	hasFoot?: boolean;
+	hasPlatformObject?: boolean;
+}

--- a/packages/components/aside/types/utils/constants.d.ts
+++ b/packages/components/aside/types/utils/constants.d.ts
@@ -1,0 +1,6 @@
+export namespace customEventNames {
+    export const CLOSE: string;
+    export const CLOSED: string;
+    export const OPEN: string;
+    export const OPENED: string;
+}

--- a/packages/components/aside/types/utils/index.d.ts
+++ b/packages/components/aside/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { customEventNames } from "./constants";

--- a/packages/components/basic-table/package.json
+++ b/packages/components/basic-table/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/basic-table.umd.js",
   "module": "lib/basic-table.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/basic-table.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/basic-table/types/basic-table.d.ts
+++ b/packages/components/basic-table/types/basic-table.d.ts
@@ -1,0 +1,6 @@
+export declare class TSBasicTable {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	cols: any[];
+	data: any[];
+	selectedIds?: any[];
+}

--- a/packages/components/basic-table/types/utils/constants.d.ts
+++ b/packages/components/basic-table/types/utils/constants.d.ts
@@ -1,0 +1,5 @@
+export namespace VISIBILITY {
+    export const ALWAYS_VISIBLE: string;
+    export const DESKTOP_ONLY: string;
+    export const MOBILE_ONLY: string;
+}

--- a/packages/components/board/package.json
+++ b/packages/components/board/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/board.umd.js",
   "module": "lib/board.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/board.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/board/types/board.d.ts
+++ b/packages/components/board/types/board.d.ts
@@ -1,0 +1,4 @@
+export declare class TSBoard {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	'data-title'?: string;
+}

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/button-group.umd.js",
   "module": "lib/button-group.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/button-group.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/button-group/types/button-group.d.ts
+++ b/packages/components/button-group/types/button-group.d.ts
@@ -1,0 +1,1 @@
+export declare class TSButtonGroup {}

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/button.umd.js",
   "module": "lib/button.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/button.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0"

--- a/packages/components/button/src/button.js
+++ b/packages/components/button/src/button.js
@@ -4,6 +4,8 @@ import '@tradeshift/elements.icon';
 import css from './button.css';
 import { types } from './utils';
 
+export { sizes, types } from './utils';
+
 export class TSButton extends TSElement {
 	static get styles() {
 		return [TSElement.styles, unsafeCSS(css)];

--- a/packages/components/button/types/button.d.ts
+++ b/packages/components/button/types/button.d.ts
@@ -1,0 +1,13 @@
+import { sizes, types } from './utils';
+
+export declare class TSButton {
+	type?: types;
+	size?: sizes;
+	busy?: boolean;
+	icon?: string;
+	disabled?: boolean;
+	grouped?: boolean;
+	dir?: 'rtl' | 'ltr' | 'auto';
+}
+
+export { sizes, types } from './utils';

--- a/packages/components/button/types/utils/constants.d.ts
+++ b/packages/components/button/types/utils/constants.d.ts
@@ -1,0 +1,13 @@
+export enum sizes {
+	MACRO = 'macro',
+	MICRO = 'micro'
+}
+
+export enum types {
+	PRIMARY = 'primary',
+	SECONDARY = 'secondary',
+	TEXT = 'text',
+	ACCEPT = 'accept',
+	WARNING = 'warning',
+	DANGER = 'danger'
+}

--- a/packages/components/button/types/utils/index.d.ts
+++ b/packages/components/button/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { sizes, types } from "./constants";

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/card.umd.js",
   "module": "lib/card.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/card.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/card/types/card.d.ts
+++ b/packages/components/card/types/card.d.ts
@@ -1,0 +1,9 @@
+export declare class TSCard {
+	type?: string;
+	orientation?: string;
+	rtl?: boolean;
+	size?: string;
+	'no-padding'?: boolean;
+	'no-horizontal-padding'?: boolean;
+	'no-vertical-padding'?: boolean;
+}

--- a/packages/components/card/types/utils/constants.d.ts
+++ b/packages/components/card/types/utils/constants.d.ts
@@ -1,0 +1,18 @@
+export namespace orientations {
+    export const HORIZONTAL: string;
+    export const H: string;
+    export const VERTICAL: string;
+    export const V: string;
+}
+export namespace types {
+    export const ERROR: string;
+    export const DANGER: string;
+    export const SUCCESS: string;
+    export const ACTIVE: string;
+    export const PRIMARY: string;
+}
+export namespace sizes {
+    export const FULL: string;
+    export const MEDIUM: string;
+    export const SMALL: string;
+}

--- a/packages/components/card/types/utils/index.d.ts
+++ b/packages/components/card/types/utils/index.d.ts
@@ -1,0 +1,2 @@
+export { default as selectors, classNames } from "./selectors";
+export { orientations, sizes, types } from "./constants";

--- a/packages/components/card/types/utils/selectors.d.ts
+++ b/packages/components/card/types/utils/selectors.d.ts
@@ -1,0 +1,5 @@
+export namespace classNames {
+    export const CARD: string;
+}
+export default selectors;
+declare const selectors: any;

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/checkbox.umd.js",
   "module": "lib/checkbox.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/checkbox.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/checkbox/types/checkbox.d.ts
+++ b/packages/components/checkbox/types/checkbox.d.ts
@@ -1,0 +1,8 @@
+export declare class TSCheckbox {
+	name?: string;
+	value?: string;
+	dir?: 'rtl' | 'ltr' | 'auto';
+	'data-label'?: string;
+	checked?: boolean;
+	disabled?: boolean;
+}

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/cover.umd.js",
   "module": "lib/cover.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/cover.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/cover/types/cover.d.ts
+++ b/packages/components/cover/types/cover.d.ts
@@ -1,0 +1,3 @@
+export declare class TSCover {
+	'data-visible'?: boolean;
+}

--- a/packages/components/document-card/package.json
+++ b/packages/components/document-card/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/document-card.umd.js",
   "module": "lib/document-card.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/document-card.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/document-card/types/document-card.d.ts
+++ b/packages/components/document-card/types/document-card.d.ts
@@ -1,0 +1,8 @@
+export declare class TSDocumentCard {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	name?: string;
+	description?: string;
+	selected?: boolean;
+	'mobile-description'?: string;
+	type?: string;
+}

--- a/packages/components/document-card/types/utils.d.ts
+++ b/packages/components/document-card/types/utils.d.ts
@@ -1,0 +1,7 @@
+export const IconsEnum: Readonly<{
+    MARKETPLACE: string;
+    PRIVATE: string;
+    OFFER: string;
+    DOCUMENT: string;
+    DEFAULT: string;
+}>;

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/file-card.umd.js",
   "module": "lib/file-card.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/file-card.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.card": "^0.13.0",

--- a/packages/components/file-card/types/file-card.d.ts
+++ b/packages/components/file-card/types/file-card.d.ts
@@ -1,0 +1,8 @@
+export declare class TSFileCard {
+	state?: string;
+	'file-object'?: object;
+	rtl?: boolean;
+	removable?: boolean;
+	size?: string;
+	'error-message'?: string;
+}

--- a/packages/components/file-card/types/utils/constants.d.ts
+++ b/packages/components/file-card/types/utils/constants.d.ts
@@ -1,0 +1,19 @@
+export namespace slotNames {
+    export const REMOVE_ACTION_TEXT: string;
+    export const DOWNLOAD_ACTION_TEXT: string;
+}
+export namespace customEventNames {
+    export const REMOVE: string;
+    export const DOWNLOAD: string;
+}
+export namespace states {
+    const DOWNLOAD_1: string;
+    export { DOWNLOAD_1 as DOWNLOAD };
+    export const FAILED: string;
+    export const UPLOADING: string;
+}
+export namespace sizes {
+    export const FULL: string;
+    export const MEDIUM: string;
+    export const SMALL: string;
+}

--- a/packages/components/file-card/types/utils/index.d.ts
+++ b/packages/components/file-card/types/utils/index.d.ts
@@ -1,0 +1,2 @@
+export const messages: any;
+export { states, customEventNames, slotNames, sizes } from './constants';

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/file-size.umd.js",
   "module": "lib/file-size.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/file-size.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.typography": "^0.13.0"

--- a/packages/components/file-size/types/file-size.d.ts
+++ b/packages/components/file-size/types/file-size.d.ts
@@ -1,0 +1,6 @@
+export declare class TSFileSize {
+	size?: number;
+	'decimal-point'?: number;
+	variant?: string;
+	type?: string;
+}

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/file-uploader-input.umd.js",
   "module": "lib/file-uploader-input.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/file-uploader-input.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.help-text": "^0.13.0",

--- a/packages/components/file-uploader-input/types/file-uploader-input.d.ts
+++ b/packages/components/file-uploader-input/types/file-uploader-input.d.ts
@@ -1,0 +1,13 @@
+export declare class TSFileUploaderInput {
+	rtl?: boolean;
+	disabled?: boolean;
+	multiple?: boolean;
+	size?: string;
+	'accepted-file-extensions'?: string[];
+	'disable-drag-and-drop'?: boolean;
+	'help-text-title'?: string;
+	'help-text-messages'?: string[];
+	'hide-file-type-help-text'?: boolean;
+	'hide-max-file-number-help-text'?: boolean;
+	'max-file-number'?: number;
+}

--- a/packages/components/file-uploader-input/types/utils/index.d.ts
+++ b/packages/components/file-uploader-input/types/utils/index.d.ts
@@ -1,0 +1,11 @@
+export const messages: any;
+export namespace slotNames {
+    export const PLACEHOLDER_TEXT: string;
+    export const BUTTON_TEXT: string;
+    export const DROP_TEXT: string;
+}
+export namespace customEventNames {
+    export const FILE_CHANGE: string;
+}
+export const sizes: any;
+export { default as selectors, classNames } from "./selectors";

--- a/packages/components/file-uploader-input/types/utils/selectors.d.ts
+++ b/packages/components/file-uploader-input/types/utils/selectors.d.ts
@@ -1,0 +1,10 @@
+export namespace classNames {
+    export const FILE_UPLOAD_WRAPPER: string;
+    export const DROP_BOX: string;
+    export const DRAGGABLE_INFO: string;
+    export const DRAG_OVER_STATE: string;
+    export const FILE_UPLOAD_BUTTON: string;
+    export const HELP_TEXT: string;
+}
+export default selectors;
+declare const selectors: any;

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/header.umd.js",
   "module": "lib/header.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/header.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.app-icon": "^0.13.0"

--- a/packages/components/header/types/header.d.ts
+++ b/packages/components/header/types/header.d.ts
@@ -1,0 +1,6 @@
+export declare class TSHeader {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	icon?: string;
+	title?: string;
+	color?: string;
+}

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/help-text.umd.js",
   "module": "lib/help-text.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/help-text.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0"

--- a/packages/components/help-text/types/help-text.d.ts
+++ b/packages/components/help-text/types/help-text.d.ts
@@ -1,0 +1,8 @@
+export declare class TSHelpText {
+	messages?: string[];
+	title?: string;
+	size?: string;
+	rtl?: boolean;
+	disabled?: boolean;
+	type?: string;
+}

--- a/packages/components/help-text/types/utils/constants.d.ts
+++ b/packages/components/help-text/types/utils/constants.d.ts
@@ -1,0 +1,12 @@
+export namespace slotNames {
+    export const TITLE: string;
+    export const MESSAGES: string;
+}
+export namespace types {
+    export const ERROR: string;
+}
+export namespace sizes {
+    export const FULL: string;
+    export const MEDIUM: string;
+    export const SMALL: string;
+}

--- a/packages/components/help-text/types/utils/index.d.ts
+++ b/packages/components/help-text/types/utils/index.d.ts
@@ -1,0 +1,2 @@
+export { classNames } from "./selectors";
+export { slotNames, sizes, types } from "./constants";

--- a/packages/components/help-text/types/utils/selectors.d.ts
+++ b/packages/components/help-text/types/utils/selectors.d.ts
@@ -1,0 +1,3 @@
+export namespace classNames {
+    export const SINGLE_MESSAGE: string;
+}

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/icon.umd.js",
   "module": "lib/icon.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/icon.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/icon/src/icon.js
+++ b/packages/components/icon/src/icon.js
@@ -4,6 +4,9 @@ import styles from './icon.css';
 import icons from './assets/icons';
 import { typeColors, types, classNames, sizes } from './utils';
 
+export { default as icons } from './assets/icons';
+export { typeColors, types, classNames, sizes } from './utils';
+
 export class TSIcon extends TSElement {
 	constructor() {
 		super();

--- a/packages/components/icon/types/assets/icons/index.d.ts
+++ b/packages/components/icon/types/assets/icons/index.d.ts
@@ -1,0 +1,14 @@
+export default icons;
+declare const icons: {
+    remove: any;
+    download: any;
+    info: any;
+    ada: any;
+    checkmark: any;
+    search: any;
+    close: any;
+    'arrow-up': any;
+    'arrow-down-short': any;
+    'arrow-left-skip': any;
+    'close-clear': any;
+};

--- a/packages/components/icon/types/icon.d.ts
+++ b/packages/components/icon/types/icon.d.ts
@@ -1,0 +1,10 @@
+export { default as icons } from './assets/icons';
+export declare class TSIcon {
+	icon?: string;
+	size?: string;
+	type?: string;
+	circular?: boolean;
+	rotate?: number;
+	flip?: string;
+}
+export { typeColors, types, classNames, sizes } from './utils';

--- a/packages/components/icon/types/utils/constants.d.ts
+++ b/packages/components/icon/types/utils/constants.d.ts
@@ -1,0 +1,25 @@
+export namespace types {
+    export const DEFAULT: string;
+    export const INVERTED: string;
+    export const PRIMARY: string;
+    export const DANGER: string;
+    export const ERROR: string;
+    export const SUCCESS: string;
+    export const ACTIVE: string;
+    export const INFO: string;
+    export const FOCUS: string;
+    export const WARNING: string;
+    export const DISABLED: string;
+    export const DISABLED_CHECKED: string;
+    export const SUGGESTED: string;
+    export const SLATE_LIGHTEST: string;
+    export const ACTION: string;
+}
+export const typeColors: {
+    [x: string]: any;
+};
+export namespace sizes {
+    export const SMALL: string;
+    export const MEDIUM: string;
+    export const LARGE: string;
+}

--- a/packages/components/icon/types/utils/index.d.ts
+++ b/packages/components/icon/types/utils/index.d.ts
@@ -1,0 +1,2 @@
+export { default as selectors, classNames } from "./selectors";
+export { typeColors, types, sizes } from "./constants";

--- a/packages/components/icon/types/utils/selectors.d.ts
+++ b/packages/components/icon/types/utils/selectors.d.ts
@@ -1,0 +1,6 @@
+export namespace classNames {
+    export const ICON_WRAPPER: string;
+    export const CIRCULAR_BG: string;
+}
+export default selectors;
+declare const selectors: any;

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/input.umd.js",
   "module": "lib/input.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/input.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/input/types/input.d.ts
+++ b/packages/components/input/types/input.d.ts
@@ -1,0 +1,3 @@
+export declare class TSInput {
+	disabled?: boolean;
+}

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/label.umd.js",
   "module": "lib/label.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/label.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/label/types/label.d.ts
+++ b/packages/components/label/types/label.d.ts
@@ -1,0 +1,3 @@
+export declare class TSLabel {
+	for?: string;
+}

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/list-item.umd.js",
   "module": "lib/list-item.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/list-item.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0",

--- a/packages/components/list-item/types/list-item.d.ts
+++ b/packages/components/list-item/types/list-item.d.ts
@@ -1,0 +1,12 @@
+export declare class TSListItem {
+	title?: string;
+	subtitle?: string;
+	disabled?: boolean;
+	selectable?: boolean;
+	selected?: boolean;
+	dir?: 'rtl' | 'ltr' | 'auto';
+	icon?: string;
+	'icon-left'?: string;
+	'icon-right'?: string;
+	'no-wrap'?: boolean;
+}

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/modal.umd.js",
   "module": "lib/modal.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/modal.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.button": "^0.13.0",

--- a/packages/components/modal/src/modal.js
+++ b/packages/components/modal/src/modal.js
@@ -5,6 +5,8 @@ import '@tradeshift/elements.header';
 import { customEventNames, sizes } from './utils';
 import css from './modal.css';
 
+export { customEventNames, sizes } from './utils';
+
 export class TSModal extends TSElement {
 	constructor() {
 		super();

--- a/packages/components/modal/types/modal.d.ts
+++ b/packages/components/modal/types/modal.d.ts
@@ -1,0 +1,14 @@
+export { customEventNames, sizes } from './utils';
+
+export declare class TSModal {
+	'data-dir'?: 'rtl' | 'ltr' | 'auto';
+	'data-size'?: string;
+	'data-title'?: string;
+	'data-visible'?: boolean;
+	'no-close-on-esc-key'?: boolean;
+	'hide-header'?: boolean;
+	'no-padding'?: boolean;
+
+	open(): void;
+	close(): void;
+}

--- a/packages/components/modal/types/utils/constants.d.ts
+++ b/packages/components/modal/types/utils/constants.d.ts
@@ -1,0 +1,10 @@
+export namespace customEventNames {
+	export const CLOSE: string;
+	export const CLOSED: string;
+	export const OPEN: string;
+	export const OPENED: string;
+}
+export namespace sizes {
+	export const MEDIUM: string;
+	export const LARGE: string;
+}

--- a/packages/components/modal/types/utils/index.d.ts
+++ b/packages/components/modal/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { customEventNames, sizes } from './constants';

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/note.umd.js",
   "module": "lib/note.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/note.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.button": "^0.13.0",

--- a/packages/components/note/types/note.d.ts
+++ b/packages/components/note/types/note.d.ts
@@ -1,0 +1,8 @@
+export declare class TSNote {
+	icon?: string;
+	type?: string;
+	dir?: 'rtl' | 'ltr' | 'auto';
+	closeable?: boolean;
+	hidden?: boolean;
+	buttons?: any[];
+}

--- a/packages/components/note/types/utils/constants.d.ts
+++ b/packages/components/note/types/utils/constants.d.ts
@@ -1,0 +1,8 @@
+export namespace customEventNames {
+    export const CLOSE: string;
+    export const BUTTON_CLICK: string;
+}
+export namespace types {
+    export const NEUTRAL: string;
+    export const ADA: string;
+}

--- a/packages/components/note/types/utils/index.d.ts
+++ b/packages/components/note/types/utils/index.d.ts
@@ -1,0 +1,3 @@
+export const messages: any;
+export { default as selectors, classNames } from "./selectors";
+export { types, customEventNames } from "./constants";

--- a/packages/components/note/types/utils/selectors.d.ts
+++ b/packages/components/note/types/utils/selectors.d.ts
@@ -1,0 +1,9 @@
+export namespace classNames {
+    export const ICON: string;
+    export const CONTENT: string;
+    export const BUTTONS_WRAPPER: string;
+    export const CLOSE_BUTTON: string;
+    export const NOTE_WRAPPER: string;
+}
+export default selectors;
+declare const selectors: any;

--- a/packages/components/pager/package.json
+++ b/packages/components/pager/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/pager.umd.js",
   "module": "lib/pager.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/pager.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0",

--- a/packages/components/pager/types/pager.d.ts
+++ b/packages/components/pager/types/pager.d.ts
@@ -1,0 +1,6 @@
+export declare class TSPager {
+	'total-pages'?: number;
+	'active-page'?: number;
+	'per-page'?: number;
+	translations?: object;
+}

--- a/packages/components/pager/types/utils/constants.d.ts
+++ b/packages/components/pager/types/utils/constants.d.ts
@@ -1,0 +1,5 @@
+export namespace customEventNames {
+    export const PAGE_CHANGE: string;
+    export const PER_PAGE_CHANGE: string;
+}
+export const perPageSelectValues: number[];

--- a/packages/components/pager/types/utils/index.d.ts
+++ b/packages/components/pager/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { customEventNames, perPageSelectValues } from "./constants";

--- a/packages/components/pager/types/utils/translations.d.ts
+++ b/packages/components/pager/types/utils/translations.d.ts
@@ -1,0 +1,8 @@
+declare var _default: {
+    page: string;
+    of: string;
+    items_per_page: string;
+    first_page_tooltip: string;
+    last_page_tooltip: string;
+};
+export default _default;

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/progress-bar.umd.js",
   "module": "lib/progress-bar.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/progress-bar.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/progress-bar/types/progress-bar.d.ts
+++ b/packages/components/progress-bar/types/progress-bar.d.ts
@@ -1,0 +1,5 @@
+export declare class TSProgressBar {
+	total?: number;
+	done?: number;
+	indeterminate?: boolean;
+}

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/radio-group.umd.js",
   "module": "lib/radio-group.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/radio-group.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/radio-group/types/radio-group.d.ts
+++ b/packages/components/radio-group/types/radio-group.d.ts
@@ -1,0 +1,7 @@
+export declare class TSRadioGroup {
+	value?: string;
+	title?: string;
+	index?: number;
+	focused?: boolean;
+	dir?: 'rtl' | 'ltr' | 'auto';
+}

--- a/packages/components/radio-group/types/utils/constants.d.ts
+++ b/packages/components/radio-group/types/utils/constants.d.ts
@@ -1,0 +1,11 @@
+export namespace customEventNames {
+    export const RADIO_CLICK: string;
+    export const RADIO_FOCUS: string;
+    export const RADIO_BLUR: string;
+    export const RADIO_SELECTED: string;
+}
+export namespace directionTypes {
+    export const BACKWARD: string;
+    export const NONE: string;
+    export const FORWARD: string;
+}

--- a/packages/components/radio-group/types/utils/index.d.ts
+++ b/packages/components/radio-group/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { customEventNames, directionTypes } from './constants';

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/radio.umd.js",
   "module": "lib/radio.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/radio.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/radio/types/radio.d.ts
+++ b/packages/components/radio/types/radio.d.ts
@@ -1,0 +1,6 @@
+export declare class TSRadio {
+	value?: string;
+	label?: string;
+	checked?: boolean;
+	disabled?: boolean;
+}

--- a/packages/components/radio/types/utils/constants.d.ts
+++ b/packages/components/radio/types/utils/constants.d.ts
@@ -1,0 +1,5 @@
+export namespace customEventNames {
+    export const RADIO_CLICK: string;
+    export const RADIO_FOCUS: string;
+    export const RADIO_BLUR: string;
+}

--- a/packages/components/radio/types/utils/index.d.ts
+++ b/packages/components/radio/types/utils/index.d.ts
@@ -1,0 +1,5 @@
+export const customEventNames: {
+    RADIO_CLICK: string;
+    RADIO_FOCUS: string;
+    RADIO_BLUR: string;
+};

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/root.umd.js",
   "module": "lib/root.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/root.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/root/types/root.d.ts
+++ b/packages/components/root/types/root.d.ts
@@ -1,0 +1,4 @@
+export declare class TSRoot {
+	ready?: boolean;
+	maximized?: boolean;
+}

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/search.umd.js",
   "module": "lib/search.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/search.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0"

--- a/packages/components/search/types/search.d.ts
+++ b/packages/components/search/types/search.d.ts
@@ -1,0 +1,8 @@
+export declare class TSSearch {
+	autofocus?: boolean;
+	dir?: 'rtl' | 'ltr' | 'auto';
+	focused?: boolean;
+	'idle-time'?: number;
+	placeholder?: string;
+	value?: string;
+}

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/spinner.umd.js",
   "module": "lib/spinner.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/spinnder.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/spinner/types/spinner.d.ts
+++ b/packages/components/spinner/types/spinner.d.ts
@@ -1,0 +1,6 @@
+export declare class TSSpinner {
+	'data-color'?: string;
+	'data-message'?: string;
+	'data-size'?: string;
+	'data-visible'?: boolean;
+}

--- a/packages/components/spinner/types/utils/constants.d.ts
+++ b/packages/components/spinner/types/utils/constants.d.ts
@@ -1,0 +1,10 @@
+export namespace sizes {
+    export const LARGE: string;
+    export const MEDIUM: string;
+    export const SMALL: string;
+}
+export namespace colors {
+    export const BLUE: string;
+    export const MONO: string;
+    export const WHITE: string;
+}

--- a/packages/components/spinner/types/utils/index.d.ts
+++ b/packages/components/spinner/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { sizes, colors } from "./constants";

--- a/packages/components/status/package.json
+++ b/packages/components/status/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/status.umd.js",
   "module": "lib/status.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/status.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/status/types/status.d.ts
+++ b/packages/components/status/types/status.d.ts
@@ -1,0 +1,5 @@
+export declare class TSStatus {
+	dir?: 'rtl' | 'ltr' | 'auto';
+	status?: string;
+	text?: string;
+}

--- a/packages/components/status/types/utils/constants.d.ts
+++ b/packages/components/status/types/utils/constants.d.ts
@@ -1,0 +1,5 @@
+export namespace STATUS_TYPE {
+    export const OK: string;
+    export const ERROR: string;
+    export const NOTE: string;
+}

--- a/packages/components/tab/package.json
+++ b/packages/components/tab/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/tab.umd.js",
   "module": "lib/tab.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/tab.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/tab/types/tab.d.ts
+++ b/packages/components/tab/types/tab.d.ts
@@ -1,0 +1,6 @@
+export declare class TSTab {
+	label?: string;
+	selected?: boolean;
+	icon?: string;
+	counter?: number;
+}

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/tabs.umd.js",
   "module": "lib/tabs.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/tabs.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0",
     "@tradeshift/elements.icon": "^0.13.0",

--- a/packages/components/tabs/types/tabs.d.ts
+++ b/packages/components/tabs/types/tabs.d.ts
@@ -1,0 +1,3 @@
+export declare class TSTabs {
+	dir?: 'rtl' | 'ltr' | 'auto';
+}

--- a/packages/components/tabs/types/utils/constants.d.ts
+++ b/packages/components/tabs/types/utils/constants.d.ts
@@ -1,0 +1,3 @@
+export namespace customEventNames {
+    export const TAB_CLICK: string;
+}

--- a/packages/components/tabs/types/utils/index.d.ts
+++ b/packages/components/tabs/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { customEventNames } from "./constants";

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/tooltip.umd.js",
   "module": "lib/tooltip.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/tooltip.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/tooltip/types/tooltip.d.ts
+++ b/packages/components/tooltip/types/tooltip.d.ts
@@ -1,0 +1,6 @@
+export declare class TSTooltip {
+	tooltip?: string;
+	position?: string;
+	width?: string;
+	disabled?: boolean;
+}

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -6,8 +6,10 @@
   "browser": "lib/typography.umd.js",
   "module": "lib/typography.esm.js",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
+  "types": "types/typography.d.ts",
   "dependencies": {
     "@tradeshift/elements": "^0.13.0"
   },

--- a/packages/components/typography/types/typography.d.ts
+++ b/packages/components/typography/types/typography.d.ts
@@ -1,0 +1,9 @@
+export declare class TSTypography {
+	text?: string;
+	tooltip?: string;
+	variant?: string;
+	type?: string;
+	inline?: boolean;
+	'no-wrap'?: boolean;
+	'no-tooltip'?: boolean;
+}

--- a/packages/components/typography/types/utils/constants.d.ts
+++ b/packages/components/typography/types/utils/constants.d.ts
@@ -1,0 +1,16 @@
+export namespace colorTypes {
+    export const DEFAULT: string;
+    export const PRIMARY: string;
+    export const DANGER: string;
+    export const ERROR: string;
+    export const SUCCESS: string;
+    export const WARNING: string;
+    export const DISABLED: string;
+    export const DISABLED_CHECKED: string;
+}
+export namespace variants {
+    const DEFAULT_1: string;
+    export { DEFAULT_1 as DEFAULT };
+    export const TITLE: string;
+    export const SUBTITLE: string;
+}

--- a/packages/components/typography/types/utils/index.d.ts
+++ b/packages/components/typography/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { colorTypes, variants } from "./constants";

--- a/packages/core/types/core.d.ts
+++ b/packages/core/types/core.d.ts
@@ -1,0 +1,11 @@
+export function customElementDefineHelper(name: any, component: any): void;
+export function validateSlottedNodes(componentName: any, slottedNodes: any, validNodes: any): void;
+export declare class TSElement extends LitElement {
+	static get styles(): import('lit-element').CSSResult[];
+	get bodyHasRTL(): boolean;
+	get bodyDir(): 'rtl' | 'ltr' | 'auto';
+	dispatchCustomEvent(eventName: any, data?: {}, delayed?: boolean): void;
+}
+import { LitElement } from 'lit-element';
+export { constants, helpers, CloseOnEscBehavior } from './utils/index';
+export { css, unsafeCSS, html } from 'lit-element';

--- a/packages/core/types/utils/behaviors.d.ts
+++ b/packages/core/types/utils/behaviors.d.ts
@@ -1,0 +1,9 @@
+export class CloseOnEscBehavior {
+    constructor(parentElement: any);
+    parentElement: any;
+    onKeyDown(event: any): void;
+    /** Registers a listener to `keydown` event. */
+    start(): void;
+    /** Unregisters a listener to `keydown` event. */
+    stop(): void;
+}

--- a/packages/core/types/utils/constants.d.ts
+++ b/packages/core/types/utils/constants.d.ts
@@ -1,0 +1,42 @@
+export const messages: any;
+export namespace sizes {
+    export const FULL: string;
+    export const MEDIUM: string;
+    export const SMALL: string;
+}
+export namespace colorModifiers {
+    export const LIGHTEST: string;
+    export const LIGHTER: string;
+    export const LIGHT: string;
+    export const DARK: string;
+    export const DARKER: string;
+}
+export namespace colors {
+    export const WHITE: string;
+    export const BLACK: string;
+    export const RED: string;
+    export const ORANGE: string;
+    export const YELLOW: string;
+    export const GREEN: string;
+    export const BLUE: string;
+    export const PURPLE: string;
+    export const PINK: string;
+    export const GRAY: string;
+    export const SLATE: string;
+}
+export namespace delay {
+    export const NOW: number;
+    export const FAST: number;
+    export const SLOW: number;
+}
+export namespace keyboardEventKeys {
+    export const ESCAPE: string;
+    export const ARROW_RIGHT: string;
+    export const ARROW_LEFT: string;
+    export const ARROW_UP: string;
+    export const ARROW_DOWN: string;
+}
+export namespace keyboardEventKeyCodes {
+    const ESCAPE_1: number;
+    export { ESCAPE_1 as ESCAPE };
+}

--- a/packages/core/types/utils/helper-functions.d.ts
+++ b/packages/core/types/utils/helper-functions.d.ts
@@ -1,0 +1,4 @@
+export function classNamesToSelector(classNamesObject: any): {};
+export function objectKeysChangeCase(object: any, toNewCase?: string): {};
+export function debounceEvent(callback: any, wait: any): (...args: any[]) => void;
+export function isEscapeKeyEvent(event: any): boolean;

--- a/packages/core/types/utils/index.d.ts
+++ b/packages/core/types/utils/index.d.ts
@@ -1,0 +1,6 @@
+export const constants: typeof constantsData;
+export const helpers: typeof helperFunctions;
+export const CloseOnEscBehavior: typeof closeBehavior;
+import * as constantsData from "./constants";
+import * as helperFunctions from "./helper-functions";
+import { CloseOnEscBehavior as closeBehavior } from "./behaviors";


### PR DESCRIPTION
- Added typings with available properties to each element.
- Changed package.json of each element according to this documentation: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Future improvements: export available enums from elements, like `customEventNames`, `sizes`, `types`, etc. For now I tried to do it for `button`, `icon`, and `modal`. I think it will help developers to use the right constants, with import them like that:
```js
import {
  TSButton,
  sizes as ButtonSizes,
  types as ButtonTypes,
} from "@tradeshift/elements.button";
```