### PR TITLE
Aditional status classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
 			<article>
 				<h2>Status</h2>
 				<div class="status-container">
-					<ts-status class="grid-status" status="ok"></ts-status>
-					<ts-status class="grid-status" status="ok" text="custom ok message"></ts-status>
+					<ts-status class="grid-status" status="success"></ts-status>
+					<ts-status class="grid-status" status="success" text="custom ok message"></ts-status>
 					<ts-status class="grid-status" status="error"></ts-status>
 					<ts-status class="grid-status" status="error" text="custom error message"></ts-status>
-					<ts-status class="grid-status" status="note"></ts-status>
-					<ts-status class="grid-status" status="note" text="custom note message"></ts-status>
-					<ts-status class="grid-status" status="note" text="LTR شسيشسي"></ts-status>
-					<ts-status class="grid-status" dir="rtl" status="note" text="RTL شسيشسي"></ts-status>
+					<ts-status class="grid-status" status="neutral"></ts-status>
+					<ts-status class="grid-status" status="neutral" text="custom note message"></ts-status>
+					<ts-status class="grid-status" status="neutral" text="LTR شسيشسي"></ts-status>
+					<ts-status class="grid-status" dir="rtl" status="neutral" text="RTL شسيشسي"></ts-status>
 				</div>
 			</article>
 
@@ -302,7 +302,7 @@
 								mobileDescription: 'Tradeshift | 5 participants',
 								type: 'document'
 							},
-							type: { status: 'ok', text: 'External' },
+							type: { status: 'success', text: 'External' },
 							participants: 100,
 							newActivity:
 								'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -332,7 +332,7 @@
 								mobileDescription: '5 participants',
 								type: 'marketplace'
 							},
-							type: { status: 'note', text: 'Internal' },
+							type: { status: 'neutral', text: 'Internal' },
 							participants: 100,
 							newActivity:
 								'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -347,7 +347,7 @@
 								mobileDescription: '2 participants',
 								type: 'private'
 							},
-							type: { status: 'note', text: 'Internal' },
+							type: { status: 'neutral', text: 'Internal' },
 							participants: 2,
 							newActivity:
 								'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',

--- a/packages/components/basic-table/stories/basic-table.happo.js
+++ b/packages/components/basic-table/stories/basic-table.happo.js
@@ -101,7 +101,7 @@ storiesOf('ts-basic-table', module).add('test', () => {
 						mobileDescription: 'Tradeshift | 5 participants',
 						type: 'document'
 					},
-					type: { status: 'ok', text: 'External' },
+					type: { status: 'success', text: 'External' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -116,7 +116,7 @@ storiesOf('ts-basic-table', module).add('test', () => {
 						mobileDescription: 'MegaImage',
 						type: 'offer'
 					},
-					type: { status: 'error', text: 'Private' },
+					type: { status: 'warning', text: 'Private' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -131,7 +131,7 @@ storiesOf('ts-basic-table', module).add('test', () => {
 						mobileDescription: '5 participants',
 						type: 'private'
 					},
-					type: { status: 'note', text: 'Internal' },
+					type: { status: 'neutral', text: 'Internal' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -146,7 +146,7 @@ storiesOf('ts-basic-table', module).add('test', () => {
 						mobileDescription: '5 participants',
 						type: 'marketplace'
 					},
-					type: { status: 'note', text: 'Internal' },
+					type: { status: 'neutral', text: 'Internal' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',

--- a/packages/components/basic-table/stories/basic-table.stories.js
+++ b/packages/components/basic-table/stories/basic-table.stories.js
@@ -52,7 +52,7 @@ storiesOf('ts-basic-table', module)
 						mobileDescription: 'Tradeshift | 5 participants',
 						type: 'offer'
 					},
-					type: { status: 'ok', text: 'External' },
+					type: { status: 'success', text: 'External' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',
@@ -82,7 +82,7 @@ storiesOf('ts-basic-table', module)
 						mobileDescription: '5 participants',
 						type: 'private'
 					},
-					type: { status: 'note', text: 'Internal' },
+					type: { status: 'neutral', text: 'Internal' },
 					participants: 100,
 					newActivity:
 						'Every little bunny has a habit that is funny. It doesnt matter where he goes he always wrinkles up his nose.',

--- a/packages/components/status/src/status.css
+++ b/packages/components/status/src/status.css
@@ -8,17 +8,27 @@
 	border-radius: var(--ts-radius);
 }
 
-.status-ok {
+.status-neutral {
+	color: var(--ts-color-slate-lightest);
+	background-color: var(--ts-color-gray-lighter);
+}
+
+.status-success {
 	color: var(--ts-color-green-darker);
 	background-color: var(--ts-color-green-lightest);
 }
 
 .status-error {
+	color: var(--ts-color-red-darker);
+	background-color: var(--ts-color-red-lightest);
+}
+
+.status-warning {
 	color: var(--ts-color-orange-darker);
 	background-color: var(--ts-color-orange-lightest);
 }
 
-.status-note {
-	color: var(--ts-color-slate-lightest);
-	background-color: var(--ts-color-gray-lighter);
+.status-primary {
+	color: var(--ts-color-blue-darker);
+	background-color: var(--ts-color-blue-lightest);
 }

--- a/packages/components/status/src/status.js
+++ b/packages/components/status/src/status.js
@@ -27,14 +27,18 @@ export class TSStatus extends TSElement {
 
 	get statusClass() {
 		switch (this.status.toLowerCase()) {
-			case STATUS_TYPE.OK:
-				return 'status-ok';
+			case STATUS_TYPE.PRIMARY:
+				return 'status-primary';
+			case STATUS_TYPE.SUCCESS:
+				return 'status-success';
 			case STATUS_TYPE.ERROR:
 				return 'status-error';
-			case STATUS_TYPE.NOTE:
-				return 'status-note';
+			case STATUS_TYPE.WARNING:
+				return 'status-warning';
+			case STATUS_TYPE.NEUTRAL:
+				return 'status-neutral';
 			default:
-				return 'status-ok';
+				return 'status-neutral';
 		}
 	}
 

--- a/packages/components/status/src/utils/constants.js
+++ b/packages/components/status/src/utils/constants.js
@@ -1,5 +1,7 @@
 export const STATUS_TYPE = {
-	OK: 'ok',
+	PRIMARY: 'primary',
+	SUCCESS: 'success',
 	ERROR: 'error',
-	NOTE: 'note'
+	WARNING: 'warning',
+	NEUTRAL: 'neutral'
 };

--- a/packages/components/status/stories/status.stories.js
+++ b/packages/components/status/stories/status.stories.js
@@ -16,7 +16,7 @@ storiesOf('ts-status', module)
 			},
 			''
 		);
-		const statusText = text('text', 'Ok Danger Note');
+		const statusText = text('text', 'Status label');
 		const dir = select(
 			'dir',
 			{


### PR DESCRIPTION
The status label is missing 2 states - primary(blue) and the error state used to be orange (corresponding to warning) instead of red.
The naming of the status was not conforming to the naming conventions we use in other components.

This PR introduces the following naming + colors:

- ok -> changed to "success"
- note -> changed to "neutral"
- error -> changed color to red instead of orange
- warning (new) -> orange (the colors that previously belonged to error)
- primary -> blue