### PR TITLE
fix: board: added default bg and changed shadow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5825,225 +5825,225 @@
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.button": "^0.14.2",
-        "@tradeshift/elements.cover": "^0.14.2",
-        "@tradeshift/elements.spinner": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.button": "^0.14.3",
+        "@tradeshift/elements.cover": "^0.14.3",
+        "@tradeshift/elements.spinner": "^0.14.3"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.card": "^0.14.2",
-        "@tradeshift/elements.file-size": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2",
-        "@tradeshift/elements.progress-bar": "^0.14.2",
-        "@tradeshift/elements.typography": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.card": "^0.14.3",
+        "@tradeshift/elements.file-size": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3",
+        "@tradeshift/elements.progress-bar": "^0.14.3",
+        "@tradeshift/elements.typography": "^0.14.3"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.typography": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.typography": "^0.14.3"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.help-text": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.help-text": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.app-icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.app-icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2",
-        "@tradeshift/elements.typography": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3",
+        "@tradeshift/elements.typography": "^0.14.3"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.button": "^0.14.2",
-        "@tradeshift/elements.cover": "^0.14.2",
-        "@tradeshift/elements.header": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.button": "^0.14.3",
+        "@tradeshift/elements.cover": "^0.14.3",
+        "@tradeshift/elements.header": "^0.14.3"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.button": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.button": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2",
-        "@tradeshift/elements.tooltip": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3",
+        "@tradeshift/elements.tooltip": "^0.14.3"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.14.2",
-        "@tradeshift/elements.icon": "^0.14.2",
-        "@tradeshift/elements.typography": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3",
+        "@tradeshift/elements.icon": "^0.14.3",
+        "@tradeshift/elements.typography": "^0.14.3"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.14.2"
+        "@tradeshift/elements": "^0.14.3"
       }
     },
     "@types/babel__core": {

--- a/packages/components/board/src/board.css
+++ b/packages/components/board/src/board.css
@@ -1,13 +1,18 @@
 /* General........................................................ */
 
-.board-container {
-	border: var(--ts-border-width) var(--ts-border-type) var(--ts-border-color-default);
-	box-shadow: 1px 2px var(--ts-shadow-color);
+:host {
+	background-color: var(--ts-color-white);
+	border: var(--ts-border);
 	border-radius: var(--ts-radius);
+	box-shadow: var(--ts-board-shadow);
+	display: block;
+	overflow: hidden;
 }
 
 .board-header {
-	border-bottom: var(--ts-border-width) var(--ts-border-type) var(--ts-border-color-default);
+	background-color: var(--ts-color-white);
+	border-bottom: var(--ts-border);
+	color: var(--ts-color-black);
 	padding: var(--ts-unit-half) var(--ts-unit);
 	font-size: var(--ts--fontsize);
 	font-weight: var(--ts-fontweight-semibold);

--- a/packages/components/board/src/board.js
+++ b/packages/components/board/src/board.js
@@ -30,11 +30,11 @@ export class TSBoard extends TSElement {
 
 	render() {
 		return html`
-			<div dir="${this.direction}" class="board-container">
+			<div dir="${this.direction}">
 				${this.header}
-				<main class="board-main">
-					<slot name="main"></slot>
-				</main>
+				<div class="board-main">
+					<slot></slot>
+				</div>
 			</div>
 		`;
 	}

--- a/packages/components/board/stories/board.stories.js
+++ b/packages/components/board/stories/board.stories.js
@@ -1,18 +1,22 @@
 import { storiesOf, html } from '@open-wc/demoing-storybook';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, text, radios } from '@storybook/addon-knobs';
 
 import '@tradeshift/elements.board';
 
 storiesOf('ts-board', module)
 	.addDecorator(withKnobs)
-	.add('default', () => {
-		const dir = text('ltr', 'Dir');
-		const title = text('My Board', 'Title');
-		const content = text('Put any html inside the board', 'Content');
-
-		return html`
-			<ts-board dir="${dir}" data-title="${title}">
-				${content}
-			</ts-board>
-		`;
-	});
+	.add(
+		'default',
+		() => {
+			const dir = radios('dir', { ltr: 'ltr', rtl: 'rtl' }, 'ltr');
+			const title = text('data-title', 'My board');
+			const mainDiv = document.createElement('div');
+			mainDiv.innerHTML = text('Put any html inside the board', '<h3>Content</h3>');
+			return html`
+				<ts-board dir="${dir}" data-title="${title}">
+					${mainDiv}
+				</ts-board>
+			`;
+		},
+		{ knobs: { escapeHTML: false } }
+	);

--- a/packages/core/src/vars.css
+++ b/packages/core/src/vars.css
@@ -161,6 +161,7 @@
 	--ts-box-width-small: 280px;
 	--ts-box-width-medium: 360px;
 	--ts-shadow-color: var(--ts-color-gray-lightest);
+	--ts-board-shadow: 0 2px 2px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.05);
 
 	/* Spinner........................................................ */
 


### PR DESCRIPTION
- Added default white background for a board element. It is defined on `:host` level, so developers can change it easily.
- Background for header will be always white and text-color will be black so the host settings will not affect the header.
- Changed box-shadow to the same we have in ts-ui.
- Fixed the story to correctly render content knob.

Some notes: for the best rendering I had to put shadow and border-radius on `:host` level and add the `overflow:hidden` to clip the inside content by corner borders. Downside of this approach is that developers can mess up with that.

Default board:
<img width="836" alt="Default board" src="https://user-images.githubusercontent.com/55530374/80799814-27663e00-8ba8-11ea-97da-11a591d3788f.png">
Board and parent with custom background:
<img width="833" alt="Board on custom bg" src="https://user-images.githubusercontent.com/55530374/80799856-3fd65880-8ba8-11ea-8066-011a23b926ca.png">

Board with custom background for content and parent with custom background:
<img width="834" alt="board on custom bg with custom bg" src="https://user-images.githubusercontent.com/55530374/80799902-609eae00-8ba8-11ea-975d-216da980aad8.png">