### PR TITLE
fix(checkbox): improved layout. Fixed a checked state management

### DIFF
--- a/packages/components/checkbox/src/checkbox.css
+++ b/packages/components/checkbox/src/checkbox.css
@@ -1,9 +1,7 @@
 /* General........................................................ */
 
 .checkbox-container {
-	display: block;
-	position: relative;
-	padding-left: var(--ts-unit-plus);
+	display: flex;
 	margin: var(--ts-unit-half);
 	cursor: pointer;
 	font-size: var(--ts-fontsize);
@@ -13,7 +11,7 @@
 	user-select: none;
 
 	&:hover {
-		& span {
+		& .checkbox {
 			background-color: var(--ts-color-gray-lighter);
 		}
 	}
@@ -26,13 +24,13 @@
 		width: 0;
 	}
 
-	& span {
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: var(--ts-unit);
-		width: var(--ts-unit);
+	& .checkbox {
 		border: var(--ts-border);
+		flex: 0 0 var(--ts-unit);
+		height: var(--ts-unit);
+		margin-right: var(--ts-unit-half);
+		position: relative;
+		width: var(--ts-unit);
 
 		&:after {
 			content: '';
@@ -49,14 +47,14 @@
 			transform: rotate(45deg);
 		}
 	}
-}
 
-.checkbox-container input:checked ~ span {
-	background-color: var(--ts-color-blue);
-	border-color: var(--ts-color-blue);
+	& input:checked ~ .checkbox {
+		background-color: var(--ts-color-blue);
+		border-color: var(--ts-color-blue);
 
-	&:after {
-		display: block;
+		&:after {
+			display: block;
+		}
 	}
 }
 
@@ -67,27 +65,26 @@
 		cursor: not-allowed;
 
 		&:hover {
-			& span {
+			& .checkbox {
 				background-color: transparent;
 			}
 		}
-		& span {
+
+		& .checkbox {
 			border: var(--ts-disabled-border);
 		}
-	}
-	& .checkbox-container input:checked ~ span {
-		background-color: var(--ts-disabled-background-color);
-		border: var(--ts-disabled-border);
+
+		& input:checked ~ .checkbox {
+			background-color: var(--ts-disabled-background-color);
+			border: var(--ts-disabled-border);
+		}
 	}
 }
 
 /* rtl ............................................................*/
 :host([dir='rtl']) {
-	& .checkbox-container {
-		padding-right: var(--ts-unit-plus);
-
-		& span {
-			right: 0;
-		}
+	& .checkbox {
+		margin-left: var(--ts-unit-half);
+		margin-right: 0;
 	}
 }

--- a/packages/components/checkbox/src/checkbox.js
+++ b/packages/components/checkbox/src/checkbox.js
@@ -36,18 +36,17 @@ export class TSCheckbox extends TSElement {
 
 	render() {
 		return html`
-			<label class="checkbox-container">
-				${this.label}
+			<div dir="${this.dir}" class="checkbox-container" @click="${this.onClick}">
 				<input
 					type="checkbox"
-					@click="${this.onClick}"
 					.name="${this.name}"
 					.value="${this.value}"
 					?checked="${this.checked}"
 					?disabled="${this.disabled}"
 				/>
-				<span></span>
-			</label>
+				<div class="checkbox"></div>
+				${this.label}
+			</div>
 		`;
 	}
 }

--- a/packages/components/checkbox/stories/checkbox.happo.js
+++ b/packages/components/checkbox/stories/checkbox.happo.js
@@ -1,0 +1,20 @@
+import { storiesOf } from '@open-wc/demoing-storybook';
+import '@tradeshift/elements';
+import '@tradeshift/elements.checkbox';
+
+import { createHappoStories } from '../../../../.storybook-happo/utils';
+
+storiesOf('ts-checkbox', module).add('test', () => {
+	const properties = {
+		dir: { rtl: 'rtl' },
+		label: { label: 'Checkbox label' },
+		disabled: { true: true },
+		checked: { true: true }
+	};
+
+	const options = {
+		columns: 4
+	};
+
+	return createHappoStories('checkbox', properties, 'Checkbox', options);
+});

--- a/packages/components/checkbox/stories/checkbox.stories.js
+++ b/packages/components/checkbox/stories/checkbox.stories.js
@@ -1,15 +1,17 @@
 import { storiesOf, html } from '@open-wc/demoing-storybook';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { withKnobs, radios, text, boolean } from '@storybook/addon-knobs';
 
 import '@tradeshift/elements.checkbox';
 
 storiesOf('ts-checkbox', module)
 	.addDecorator(withKnobs)
 	.add('default', () => {
-		const label = text('label', 'Label');
-		const disabled = boolean('Disabled', false);
+		const dir = radios('dir', { ltr: 'ltr', rtl: 'rtl' }, 'ltr');
+		const label = text('data-label', 'Label');
+		const checked = boolean('checked', false);
+		const disabled = boolean('disabled', false);
 
 		return html`
-			<ts-checkbox ?disabled="${disabled}" data-label="${label}"> </ts-checkbox>
+			<ts-checkbox dir="${dir}" ?disabled="${disabled}" ?checked="${checked}" data-label="${label}"> </ts-checkbox>
 		`;
 	});


### PR DESCRIPTION
- Fixed #275 

- Fixed a `checked` state management. Before there could be unexpected behaviour:
  - render checkbox in `checked` state
  - User unchecks it.
  - set `checked` attribute from code.
  - Now it will have a `checked` attribute but will render unchecked. If user will click on it, a `checked` attribute removed but checkbox rendered in checked state.

- Added a few knobs to a story.