### PR TITLE
fix(checkbox): returned a click event propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5825,225 +5825,225 @@
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.button": "^0.14.3",
-        "@tradeshift/elements.cover": "^0.14.3",
-        "@tradeshift/elements.spinner": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.button": "^0.15.0",
+        "@tradeshift/elements.cover": "^0.15.0",
+        "@tradeshift/elements.spinner": "^0.15.0"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.card": "^0.14.3",
-        "@tradeshift/elements.file-size": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3",
-        "@tradeshift/elements.progress-bar": "^0.14.3",
-        "@tradeshift/elements.typography": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.card": "^0.15.0",
+        "@tradeshift/elements.file-size": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0",
+        "@tradeshift/elements.progress-bar": "^0.15.0",
+        "@tradeshift/elements.typography": "^0.15.0"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.typography": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.typography": "^0.15.0"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.help-text": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.help-text": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.app-icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.app-icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3",
-        "@tradeshift/elements.typography": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0",
+        "@tradeshift/elements.typography": "^0.15.0"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.button": "^0.14.3",
-        "@tradeshift/elements.cover": "^0.14.3",
-        "@tradeshift/elements.header": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.button": "^0.15.0",
+        "@tradeshift/elements.cover": "^0.15.0",
+        "@tradeshift/elements.header": "^0.15.0"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.button": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.button": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3",
-        "@tradeshift/elements.tooltip": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0",
+        "@tradeshift/elements.tooltip": "^0.15.0"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.14.3",
-        "@tradeshift/elements.icon": "^0.14.3",
-        "@tradeshift/elements.typography": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0",
+        "@tradeshift/elements.icon": "^0.15.0",
+        "@tradeshift/elements.typography": "^0.15.0"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.14.3"
+        "@tradeshift/elements": "^0.15.0"
       }
     },
     "@types/babel__core": {
@@ -14575,28 +14575,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -14607,14 +14607,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -14625,42 +14625,42 @@
         },
         "chownr": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "optional": true,
@@ -14670,28 +14670,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "optional": true,
@@ -14701,14 +14701,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -14725,7 +14725,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "optional": true,
@@ -14740,14 +14740,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -14757,7 +14757,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "optional": true,
@@ -14767,7 +14767,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -14778,21 +14778,21 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -14802,14 +14802,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -14819,14 +14819,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
           "optional": true,
@@ -14837,7 +14837,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "optional": true,
@@ -14847,7 +14847,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -14857,14 +14857,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "dev": true,
           "optional": true,
@@ -14876,7 +14876,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "dev": true,
           "optional": true,
@@ -14895,7 +14895,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -14906,7 +14906,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "optional": true,
@@ -14916,14 +14916,14 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
           "dev": true,
           "optional": true,
@@ -14934,7 +14934,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -14947,21 +14947,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -14971,21 +14971,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -14996,21 +14996,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -15023,7 +15023,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -15032,7 +15032,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -15048,7 +15048,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "optional": true,
@@ -15058,49 +15058,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -15112,7 +15112,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -15122,7 +15122,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -15132,14 +15132,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
@@ -15155,14 +15155,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -15172,14 +15172,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true

--- a/packages/components/checkbox/src/checkbox.js
+++ b/packages/components/checkbox/src/checkbox.js
@@ -26,8 +26,7 @@ export class TSCheckbox extends TSElement {
 		return this.dir || this.bodyDir;
 	}
 
-	onClick(e) {
-		e.stopPropagation();
+	onClick() {
 		if (this.disabled) {
 			return;
 		}


### PR DESCRIPTION
In the previous commit, I accidentally added the `event.stopPropagation()` method call for the `click` event, which is why all listeners outside the element stopped receiving this event.
Now I fix this.