### PR TITLE
NAV-412. Hide the Allowed formats message for empty array

### DIFF
--- a/packages/components/file-uploader-input/src/file-uploader-input.js
+++ b/packages/components/file-uploader-input/src/file-uploader-input.js
@@ -103,7 +103,7 @@ export class TSFileUploaderInput extends TSElement {
 
 	get helpText() {
 		const helpTextList = [...this.helpTextMessages];
-		if (!this.hideFileTypeHelpText && this.acceptedFileExtensions) {
+		if (!this.hideFileTypeHelpText && this.acceptedFileExtensions && this.acceptedFileExtensions.length > 0) {
 			const acceptedFileExtensions = this.acceptedFileExtensions.map(ext => ext.toUpperCase()).join(', ');
 			helpTextList.push(`${messages.ALLOWED_FORMATS}: ${acceptedFileExtensions}`);
 		}


### PR DESCRIPTION
We already hiding the Allowed formats help message when this property is undefined, but the component should have the same behaviour when the provided array of available extensions is empty.