### PR TITLE
fix: Do not preselect the first radio without checked attr

### DIFF
--- a/packages/components/radio-group/src/radio-group.js
+++ b/packages/components/radio-group/src/radio-group.js
@@ -75,7 +75,7 @@ export class TSRadioGroup extends TSElement {
 	handleSlotChange() {
 		this.radios = this.radioElements;
 
-		this.index = 0;
+		this.index = -1;
 		for (let i = 0; i < this.radios.length; i++) {
 			if (this.radios[i].checked) {
 				this.index = i;

--- a/packages/components/radio-group/src/utils/helper-functions.js
+++ b/packages/components/radio-group/src/utils/helper-functions.js
@@ -25,7 +25,7 @@ export function getNextElementIndex(direction, index, collectionLength) {
 			index++;
 			return index;
 		case directionTypes.BACKWARD:
-			if (index === 0) {
+			if (index === 0 || index === -1) {
 				return collectionLength - 1;
 			}
 			index--;


### PR DESCRIPTION
According to MDN having none radios checked in the beginning is a valid situation which is not the case for our elements https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#Value. I've added negative index to handle this. It'll work with keyboard navigation as well. First `toggle` won't do anything without having a radioElement and it's the case with the negative index.