### PR TITLE
Fix peer dep issue with npm@7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10185,235 +10185,239 @@
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.button": "^0.18.1",
-        "@tradeshift/elements.cover": "^0.18.1",
-        "@tradeshift/elements.spinner": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.button": "^0.19.1",
+        "@tradeshift/elements.cover": "^0.19.1",
+        "@tradeshift/elements.spinner": "^0.19.1"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.dialog": {
       "version": "file:packages/components/dialog",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1",
-        "@tradeshift/elements.modal": "^0.18.1",
-        "@tradeshift/elements.typography": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.button": "^0.19.1",
+        "@tradeshift/elements.button-group": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1",
+        "@tradeshift/elements.modal": "^0.19.1",
+        "@tradeshift/elements.typography": "^0.19.1"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.card": "^0.18.1",
-        "@tradeshift/elements.file-size": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1",
-        "@tradeshift/elements.progress-bar": "^0.18.1",
-        "@tradeshift/elements.typography": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.card": "^0.19.1",
+        "@tradeshift/elements.file-size": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1",
+        "@tradeshift/elements.progress-bar": "^0.19.1",
+        "@tradeshift/elements.typography": "^0.19.1"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.typography": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.typography": "^0.19.1"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.help-text": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.help-text": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.app-icon": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.app-icon": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1",
-        "@tradeshift/elements.typography": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1",
+        "@tradeshift/elements.typography": "^0.19.1"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.button": "^0.18.1",
-        "@tradeshift/elements.cover": "^0.18.1",
-        "@tradeshift/elements.header": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.button": "^0.19.1",
+        "@tradeshift/elements.cover": "^0.19.1",
+        "@tradeshift/elements.header": "^0.19.1"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.button": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.button": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1",
-        "@tradeshift/elements.tooltip": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1",
+        "@tradeshift/elements.tooltip": "^0.19.1"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.radio": "^0.19.1"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.18.1",
-        "@tradeshift/elements.icon": "^0.18.1",
-        "@tradeshift/elements.typography": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1",
+        "@tradeshift/elements.icon": "^0.19.1",
+        "@tradeshift/elements.tab": "^0.19.1",
+        "@tradeshift/elements.typography": "^0.19.1"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.18.1"
+        "@tradeshift/elements": "^0.19.1"
       }
     },
     "@types/anymatch": {

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -14,6 +14,8 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.19.1",
+    "@tradeshift/elements.button": "^0.19.1",
+    "@tradeshift/elements.button-group": "^0.19.1",
     "@tradeshift/elements.icon": "^0.19.1",
     "@tradeshift/elements.modal": "^0.19.1",
     "@tradeshift/elements.typography": "^0.19.1"

--- a/packages/components/dialog/src/dialog.js
+++ b/packages/components/dialog/src/dialog.js
@@ -1,7 +1,9 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper, validateSlottedNodes } from '@tradeshift/elements';
+import '@tradeshift/elements.button';
+import '@tradeshift/elements.button-group';
+import '@tradeshift/elements.icon';
 import '@tradeshift/elements.modal';
 import '@tradeshift/elements.typography';
-import '@tradeshift/elements.icon';
 
 import css from './dialog.css';
 import { translations, dialogTypes, dialogTypeIcon, dialogTypeIconTypes, dialogTypeButtonType } from './utils';

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -15,10 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.19.1"
-  },
-  "peerDependencies": {
-    "@tradeshift/elements.radio": "^0.9.0"
+    "@tradeshift/elements": "^0.19.1",
+    "@tradeshift/elements.radio": "^0.19.1"
   },
   "src": "src/radio-group.js"
 }

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -17,10 +17,8 @@
   "dependencies": {
     "@tradeshift/elements": "^0.19.1",
     "@tradeshift/elements.icon": "^0.19.1",
+    "@tradeshift/elements.tab": "^0.19.1",
     "@tradeshift/elements.typography": "^0.19.1"
-  },
-  "peerDependencies": {
-    "@tradeshift/elements.tab": "^0.9.0"
   },
   "src": "src/tabs.js"
 }

--- a/packages/components/tabs/src/tabs.js
+++ b/packages/components/tabs/src/tabs.js
@@ -4,6 +4,7 @@ import { customEventNames } from './utils';
 
 import '@tradeshift/elements.icon';
 import '@tradeshift/elements.typography';
+import '@tradeshift/elements.tab';
 
 export class TSTabs extends TSElement {
 	constructor() {
@@ -51,18 +52,14 @@ export class TSTabs extends TSElement {
 			return '';
 		}
 		const type = tab.icon === 'ada' ? 'suggested' : 'default';
-		return html`
-			<ts-icon icon="${tab.icon}" type="${type}" size="medium"></ts-icon>
-		`;
+		return html` <ts-icon icon="${tab.icon}" type="${type}" size="medium"></ts-icon> `;
 	}
 
 	badgeTemplate(tab) {
 		if (!tab.counter) {
 			return '';
 		}
-		return html`
-			<em class="badge">${tab.counter}</em>
-		`;
+		return html` <em class="badge">${tab.counter}</em> `;
 	}
 
 	tabTemplate(tab, index) {
@@ -120,12 +117,7 @@ export class TSTabs extends TSElement {
 	render() {
 		return html`
 			<header class="tabs-wrapper" dir="${this.direction}">
-				${this.tabs.map(
-					(tab, index) =>
-						html`
-							${this.tabTemplate(tab, index)}
-						`
-				)}
+				${this.tabs.map((tab, index) => html` ${this.tabTemplate(tab, index)} `)}
 			</header>
 			<div class="tabs-content-wrapper">
 				<slot @slotchange="${this.slotChangeHandler}"></slot>


### PR DESCRIPTION

- Move peer deps to dependencies:

  Based on the changes that have been done about peerDependencies in the npm@7 it caused error for projects that've being using the radio-group or tabs. `tab` and `radio` components are added to dependencies of `tabs` and `radio-group` since they are actually useless without those components and it makes developers life easier to just handle one dep if they only need those group components and not import the child component.
  
- fix: Add missing dependencies of dialog component