### PR TITLE
[PEAA-57] fix(pager): fixed a css media query for mobile devices

### DIFF
--- a/packages/components/pager/src/pager.css
+++ b/packages/components/pager/src/pager.css
@@ -123,7 +123,7 @@ li {
 	}
 }
 
-@media screen and (env(--mobile-screen-breakpoint)) {
+@media screen and (max-width: env(--mobile-screen-breakpoint)) {
 	.container {
 		margin: var(--ts-unit-half);
 	}


### PR DESCRIPTION
Fixed a mistake in css rule that blocks a transition of ts-pager to mobile state. Now it should work fine.
![Pager mobile](https://user-images.githubusercontent.com/55530374/109039227-d7271200-76cc-11eb-93d6-77d2a57dae3d.png)
