### PR TITLE
feat(popover): PEAA-316. Added an initial implementation for popover.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5030,6 +5030,13 @@
         "@tradeshift/elements.tooltip": "^0.19.3"
       }
     },
+    "@tradeshift/elements.popover": {
+      "version": "file:packages/components/popover",
+      "requires": {
+        "@tradeshift/elements": "^0.19.3",
+        "@tradeshift/elements.icon": "^0.19.3"
+      }
+    },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@tradeshift/elements.modal": "file:packages/components/modal",
     "@tradeshift/elements.note": "file:packages/components/note",
     "@tradeshift/elements.pager": "file:packages/components/pager",
+    "@tradeshift/elements.popover": "file:packages/components/popover",
     "@tradeshift/elements.progress-bar": "file:packages/components/progress-bar",
     "@tradeshift/elements.radio": "file:packages/components/radio",
     "@tradeshift/elements.radio-group": "file:packages/components/radio-group",

--- a/packages/components/popover/README.md
+++ b/packages/components/popover/README.md
@@ -1,0 +1,161 @@
+<h1 align="center">
+    <a href="https://tradeshift.com/">
+      <img alt="Tradeshift" src="https://tradeshift.com/wp-content/themes/Tradeshift/img/brand/logo-black.png"/>
+    </a>
+</h1>
+
+<h1 align="center">Elements - popover</h1>
+
+<p align="center">
+  Part of the reusable Tradeshift UI Components as Web Components.
+    <a href="https://tradeshift.github.io/elements/?path=/story/ts-popover--default">
+      Demo
+    </a>
+</p>
+
+<p align="center">
+    <a href="https://www.npmjs.com/package/@tradeshift/elements.popover">
+      <img alt="NPM Version" src="https://badgen.net/npm/v/@tradeshift/elements.popover" height="20"/>
+    </a>
+    <a href="https://npmcharts.com/compare/@tradeshift/elements.popover?minimal=true">
+		  <img alt="Downloads per month" src="https://badgen.net/npm/dm/@tradeshift/elements.popover" height="20"/>
+		</a>
+		<a href="https://www.npmjs.com/browse/depended/@tradeshift/elements.popover">
+		  <img alt="Dependent packages" src="https://badgen.net/npm/dependents/@tradeshift/elements.popover" height="20"/>
+		</a>
+</p>
+
+<style>
+  table {
+        width:100%;
+  }
+</style>
+
+## ➤ Properties
+
+| Property | Attribute | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| opened | opened | Boolean | false | Is the popover visible or not |
+| placement | placement | String |  | Placement, relative to the anchor. Could be 'topLeft', 'topRight', 'bottomLeft', 'bottomRight' |
+| header | header | String |  | Text in the title |
+| anchor | anchor | String |  | Anchor element for relative positioning. If you need to position absolutely, leave this empty |
+| positionLeft | position-left | String |  | Left offset when popover is positioned absolutely. Use any valid css syntax for the 'left' property |
+| positionTop | position-top | String |  | Top offset when popover is positioned absolutely. Use any valid css syntax for the 'top' property |
+
+## ➤ Slots
+
+| Name    | Description                                                                        |
+| ------- | ---------------------------------------------------------------------------------- |
+| content | Content in the main section of the popover                                         |
+| footer  | Content in the footer section of the popover, most of the time \`ts-button-group\` |
+
+## ➤ Events
+
+| Name          | Description                                         | Payload |
+| ------------- | --------------------------------------------------- | ------- |
+| popover-close | Emitted when user press the close button in popover |         |
+
+## ➤ How to use it
+
+- Install the package of popover
+
+```shell
+$ npm i @tradeshift/elements.popover --save
+```
+
+- Import the component
+
+```js
+import '@tradeshift/elements.popover';
+```
+
+or
+
+```html
+<script src="node_modules/@tradeshift/elements.popover/lib/popover.umd.js"></script>
+```
+
+- Use it like [demo]("https://tradeshift.github.io/elements/?path=/story/ts-popover--default")
+
+- Our components rely on having the `Open Sans` available, You can see the `font-weight` and `font-style` you need to load [here](https://github.com/Tradeshift/elements/blob/master/packages/core/src/fonts.css), or you can just load it from our package (for now)
+
+```html
+<link rel="stylesheet" href="node_modules/@tradeshift/elements/src/fonts.css" />
+```
+
+## ➤ Polyfills
+
+For supporting IE11 you need to add couple of things
+
+- Don't shim CSS Custom Properties in IE11
+
+```html
+<!-- Place this in the <head>, before the Web Component polyfills are loaded -->
+<script>
+	if (!window.Promise) {
+		window.ShadyCSS = { nativeCss: true };
+	}
+</script>
+```
+
+##### You have two options for polyfills library:
+
+1. Use [`@open-wc/polyfills-loader`](https://github.com/open-wc/open-wc/tree/master/packages/polyfills-loader)
+
+- Installation
+
+```shell
+$ npm i @open-wc/polyfills-loader
+```
+
+- Load it
+
+```js
+import loadPolyfills from '@open-wc/polyfills-loader';
+
+loadPolyfills().then(() => import('./my-app.js'));
+```
+
+2. Use [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs)
+
+- Installation
+
+```hell
+$ npm i @webcomponents/webcomponentsjs --save
+```
+
+- Enable ES5 class-less Custom Elements
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+```
+
+- Load appropriate polyfills and shims with [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/webcomponentsjs)
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+```
+
+## ➤ How to contribute
+
+Thanks for your interest and help!
+
+- First thing you need to do is read this [[Component Checklist](https://github.com/Tradeshift/elements/wiki/Component-checklist)] which contains lots of important information about what you need to consider when you are creating/changing components
+
+##### [General info](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter)
+
+You can find some [links to useful materials](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter) about what we are using and some tutorials and articles that can help you get started.
+
+## ➤ [Polyfill Limitations](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+You can see a list of limitations that we should watch out for, [here](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+## ➤ License
+
+- You can always create forks on GitHub, submit Issues and Pull Requests.
+- You can only use Tradeshift Elements to make apps on a Tradeshift platform, e.g. tradeshift.com.
+- You can fix a bug until the bugfix is deployed by Tradeshift.
+- You can host Tradeshift Elements yourself.
+- If you want to make a bigger change or just want to talk with us, reach out to our team here on GitHub.
+
+You can read the full license agreement in the [LICENSE.md](https://github.com/Tradeshift/elements/blob/master/LICENSE.md).

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tradeshift/elements.popover",
+  "version": "0.19.3",
+  "main": "lib/popover.umd.js",
+  "module": "lib/popover.esm.js",
+  "browser": "lib/popover.umd.js",
+  "files": [
+    "lib/*"
+  ],
+  "dependencies": {
+    "@tradeshift/elements": "^0.19.3",
+    "@tradeshift/elements.icon": "^0.19.3"
+  },
+  "src": "src/popover.js"
+}

--- a/packages/components/popover/src/popover.css
+++ b/packages/components/popover/src/popover.css
@@ -1,0 +1,51 @@
+/* General........................................................ */
+:host {
+	display: none;
+	outline: none;
+	pointer-events: none;
+}
+
+:host([opened]) {
+	display: block;
+	z-index: var(--ts-zindex-max);
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.popover-container {
+	background: var(--ts-color-black);
+	color: var(--ts-color-white);
+	font-size: var(--ts-fontsize-small);
+	padding: var(--ts-unit-half);
+	border-radius: var(--ts-radius);
+	position: absolute;
+	pointer-events: all;
+	max-width: 375px;
+}
+
+.popover-header {
+	height: var(--ts-unit);
+	display: flex;
+	justify-content: space-between;
+	font-size: var(--ts-fontsize-small);
+
+	& .popover-title {
+		flex: 1 1 var(--ts-unit-half);
+		font-weight: var(--ts-fontweight-semibold);
+	}
+
+	& .popover-close {
+		flex: 0 0 var(--ts-unit-half);
+		margin-left: var(--ts-unit-half);
+		cursor: pointer;
+	}
+}
+
+.popover-footer {
+	display: flex;
+	justify-content: flex-end;
+	font-size: var(--ts-fontsize-small);
+}

--- a/packages/components/popover/src/popover.js
+++ b/packages/components/popover/src/popover.js
@@ -1,0 +1,190 @@
+import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import '@tradeshift/elements.icon';
+import css from './popover.css';
+
+/**
+ * Placement relative to the anchor element.
+ */
+export const Placement = {
+	TOP_LEFT: 'topLeft',
+	TOP_RIGHT: 'topRight',
+	BOTTOM_LEFT: 'bottomLeft',
+	BOTTOM_RIGHT: 'bottomRight'
+};
+
+export class TSPopover extends TSElement {
+	static get styles() {
+		return [TSElement.styles, unsafeCSS(css)];
+	}
+
+	static get properties() {
+		return {
+			/** Is the popover visible or not */
+			opened: { type: Boolean, reflect: true },
+			/** Placement, relative to the anchor. Could be 'topLeft', 'topRight', 'bottomLeft', 'bottomRight' */
+			placement: { type: String, attribute: 'placement', reflect: true },
+			/** Text in the title */
+			header: { type: String, reflect: true },
+			/** Anchor element for relative positioning. If you need to position absolutely, leave this empty */
+			anchor: { type: String, reflect: true },
+			/** Left offset when popover is positioned absolutely. Use any valid css syntax for the 'left' property */
+			positionLeft: { type: String, attribute: 'position-left', reflect: true },
+			/** Top offset when popover is positioned absolutely. Use any valid css syntax for the 'top' property */
+			positionTop: { type: String, attribute: 'position-top', reflect: true }
+		};
+	}
+
+	constructor() {
+		super();
+		this.opened = false;
+	}
+
+	onClose() {
+		/**
+		 * Emitted when user press the close button in popover
+		 */
+		this.dispatchCustomEvent('popover-close');
+		this.opened = false;
+	}
+
+	stopEventBubbling(e) {
+		e.stopPropagation();
+	}
+
+	attributeChangedCallback(name, oldVal, newVal) {
+		super.attributeChangedCallback(name, oldVal, newVal);
+		switch (name) {
+			case 'opened':
+				if (newVal !== null) {
+					window.customElements.whenDefined('ts-popover').then(() => {
+						const container = this.shadowRoot.getElementById('container');
+						if (!container) {
+							// it could happen when element is just initialised but not rendered yet.
+							return;
+						}
+						if (this.anchor) {
+							this.placeWithAnchor(container);
+						} else {
+							this.placeAbsolutely(container);
+						}
+					});
+				}
+				break;
+
+			default:
+			// do nothing
+		}
+	}
+
+	placeAbsolutely(container) {
+		const position = {
+			left: `${this.positionLeft}`,
+			top: `${this.positionTop}`
+		};
+		Object.assign(container.style, position);
+	}
+
+	placeWithAnchor(container) {
+		const anchor = this.getByIdFromParents(this, this.anchor);
+		const containerRect = container.getBoundingClientRect();
+		const { innerHeight, innerWidth } = window;
+		const { left, top, width = 0, height = 0 } = anchor.getBoundingClientRect();
+		const halfUnit = 10;
+		const position = {
+			top: 'auto',
+			right: 'auto',
+			bottom: 'auto',
+			left: 'auto'
+		};
+
+		let translateX = 0;
+		let translateY = 0;
+
+		switch (this.placement) {
+			case Placement.TOP_LEFT:
+			case Placement.BOTTOM_LEFT:
+				// Check, does the container will fit into window on the left side with desired offset.
+				// if not, then stick it to the left side of the window.
+				position.left = `${left - halfUnit}px`;
+				if (left - halfUnit > containerRect.width) {
+					translateX = -100;
+				} else {
+					position.left = `${halfUnit}px`;
+				}
+				break;
+			case Placement.TOP_RIGHT:
+			case Placement.BOTTOM_RIGHT:
+				// Check, does the container will fit into window on the right side with desired offset.
+				// if not, then stick it to the right side of the window.
+				if (left + width + containerRect.width + halfUnit > innerWidth) {
+					position.left = `${innerWidth - containerRect.width - halfUnit}px`;
+				} else {
+					position.left = `${left + width + halfUnit}px`;
+				}
+				break;
+		}
+
+		switch (this.placement) {
+			case Placement.TOP_LEFT:
+			case Placement.TOP_RIGHT:
+				// Check, does the container will fit into window on the top with desired offset.
+				// if not, then stick it to the top side of the window.
+				if (top + height > containerRect.height) {
+					position.top = `${top + height - halfUnit}px`;
+					translateY = -100;
+				} else {
+					position.top = '0px';
+				}
+				break;
+			case Placement.BOTTOM_LEFT:
+			case Placement.BOTTOM_RIGHT:
+				// Check, does the container will fit into window on the bottom with desired offset.
+				// if not, then stick it to the bottom side of the window.
+				if (top + containerRect.height + halfUnit > innerHeight) {
+					position.top = `${innerHeight - containerRect.height - halfUnit}px`;
+				} else {
+					position.top = `${top + halfUnit}px`;
+				}
+				break;
+		}
+
+		position.transform = `translate(${translateX}%, ${translateY}%)`;
+		Object.assign(container.style, position);
+	}
+
+	getByIdFromParents($elem, query) {
+		// If a shadow root doesn't exist we don't continue the traversal
+		if ($elem.shadowRoot == null) {
+			return null;
+		}
+
+		// Grab the root node and query it
+		const $root = $elem.shadowRoot.host.getRootNode();
+		const result = $root.getElementById(query);
+		if (result) {
+			return result;
+		}
+
+		// We continue the traversal if there was not matches
+		return this.getByIdFromParents($root, query);
+	}
+
+	render() {
+		return html`
+			<div id="container" class="popover-container" @click=${this.stopEventBubbling}>
+				<div class="popover-header">
+					<span class="popover-title">${this.header || ''}</span>
+					<ts-icon icon="close" size="medium" type="inverted" class="popover-close" @click=${this.onClose}></ts-icon>
+				</div>
+				<!-- Content in the main section of the popover	-->
+				<slot name="content"></slot>
+				<div class="popover-footer">
+					<!-- Content in the footer section of the popover, most of the time \`ts-button-group\`	-->
+					<slot name="footer"></slot>
+				</div>
+			</div>
+		`;
+	}
+}
+
+customElementDefineHelper('ts-popover', TSPopover);

--- a/packages/components/popover/stories/popover.happo.js
+++ b/packages/components/popover/stories/popover.happo.js
@@ -1,0 +1,62 @@
+import { html } from 'lit-html';
+import '@tradeshift/elements';
+import '@tradeshift/elements.popover';
+
+export default {
+	title: 'ts-popover'
+};
+
+export const AnchoredPosition = () => {
+	return html`
+		<div style="margin-top: 150px; text-align: center; position:relative; width: 100%; height: 300px;">
+			<span id="anchorElem" style="border: 1px solid green;">Anchor element</span>
+		</div>
+		<ts-popover placement="topLeft" header="TopLeft header" anchor="anchorElem" opened>
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+			</div>
+		</ts-popover>
+		<ts-popover placement="topRight" header="TopRight header" anchor="anchorElem" opened>
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+			</div>
+		</ts-popover>
+		<ts-popover placement="bottomLeft" header="BottomLeft header" anchor="anchorElem" opened>
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+			</div>
+		</ts-popover>
+		<ts-popover placement="bottomRight" header="BottomRight header" anchor="anchorElem" opened>
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+			</div>
+		</ts-popover>
+	`;
+};
+
+AnchoredPosition.story = {
+	name: 'anchored position'
+};
+
+export const AbsolutelyPositioned = () => {
+	return html`
+		<ts-popover position-left="50px" position-top="calc(50% - 20px)" opened>
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+			</div>
+			<div slot="footer">
+				<button>First</button>
+				<button>Second</button>
+			</div>
+		</ts-popover>
+	`;
+};
+
+AbsolutelyPositioned.story = {
+	name: 'absolute position'
+};

--- a/packages/components/popover/stories/popover.stories.js
+++ b/packages/components/popover/stories/popover.stories.js
@@ -1,0 +1,71 @@
+import { html } from 'lit-html';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+
+import { Placement } from '@tradeshift/elements.popover';
+import { helpers } from '@tradeshift/elements';
+import readme from '../README.md';
+
+export default {
+	title: 'ts-popover',
+	decorators: [withKnobs]
+};
+
+export const Default = () => {
+	const placement = select('placement', helpers.objectKeysChangeCase(Placement), 'topRight');
+	const header = text('header', 'This is header');
+	const opened = boolean('opened', false);
+
+	return html`
+		<div style="margin-top: 150px; text-align: center; position:relative">
+			<span id="anchorElem" style="border: 1px solid green;">Anchor element</span>
+		</div>
+		<ts-popover placement="${placement}" header="${header}" anchor="anchorElem" ?opened="${opened}">
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+				<ul>
+					<li>item 1</li>
+					<li>item 2</li>
+				</ul>
+			</div>
+			<div slot="footer">
+				<ts-button size="micro">First</ts-button>
+				<ts-button size="micro">Second</ts-button>
+			</div>
+		</ts-popover>
+	`;
+};
+
+export const AbsolutePosition = () => {
+	const positionLeft = text('position-left', '30px');
+	const positionTop = text('position-top', '50px');
+	const header = text('header', 'This is header');
+	const opened = boolean('opened', true);
+
+	return html`
+		<ts-popover position-left="${positionLeft}" position-top="${positionTop}" header="${header}" ?opened="${opened}">
+			<div slot="content">
+				<p>In popover content you could use html markup, e.g.:</p>
+				<a href="#" style="color: skyblue">link</a>
+				<ul>
+					<li>item 1</li>
+					<li>item 2</li>
+				</ul>
+			</div>
+			<div slot="footer">
+				<ts-button size="micro">First</ts-button>
+				<ts-button size="micro">Second</ts-button>
+			</div>
+		</ts-popover>
+	`;
+};
+
+Default.story = {
+	name: 'default',
+	parameters: { notes: readme }
+};
+
+AbsolutePosition.story = {
+	name: 'absolute position',
+	parameters: { notes: readme }
+};

--- a/rollup.globals.json
+++ b/rollup.globals.json
@@ -19,6 +19,7 @@
 	"@tradeshift/elements.label": "ts.elements.label",
 	"@tradeshift/elements.modal": "ts.elements.modal",
 	"@tradeshift/elements.pager": "ts.elements.pager",
+	"@tradeshift/elements.popover": "ts.elements.popover",
 	"@tradeshift/elements.progress-bar": "ts.elements.progress-bar",
 	"@tradeshift/elements.radio": "ts.elements.radio",
 	"@tradeshift/elements.radio-group": "ts.elements.radio-group",

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -2,11 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const xa = require('xa');
 
-const compStateLogger = function(componentName, text) {
+const compStateLogger = function (componentName, text) {
 	xa.custom(componentName.toUpperCase(), text, { titleColor: 'yellow', backgroundColor: '#212121' });
 };
 
-const getComponentNames = function() {
+const getComponentNames = function () {
 	const componentsPath = path.join(process.cwd(), '/packages/components');
 	const componentNames = fs.readdirSync(componentsPath);
 	// const componentNames = staticComponentNames();
@@ -47,6 +47,7 @@ function staticComponentNames() {
 		'modal',
 		'note',
 		'pager',
+		'popover',
 		'progress-bar',
 		'radio',
 		'radio-group',


### PR DESCRIPTION
Added an initial implementation of the popover element.

There are two ways to close the popover: by pressing the `X` button on top right of the popover or via API by setting `opened` property to `false`.

If the anchor element is defined, it will try to position the popover relative to this anchor. Developer should specify `placement` to define where the popover should be rendered.

If the anchor is not specified, popover will be placed absolutely, based on the values in `positionLeft` and `positionTop`, which accepts any valid css syntax, e.g. `50px`, `50%`, `calc(100%-50px)`.

Screenshot:
<img width="665" alt="Popover" src="https://user-images.githubusercontent.com/55530374/112440805-03c15e80-8d4b-11eb-8739-7fb0b452d5c0.png">
