### PR TITLE
chore(backstage): Updated catalog-info with the correct owner

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,4 +1,3 @@
-
 # catalog-info.yml
 # This file contains metadata for backstage
 # Read more about available fields and annotations:
@@ -20,5 +19,5 @@ metadata:
     - npm
 spec:
   type: library
-  owner: tradeshiftui
+  owner: partner-enablement-and-apps
   lifecycle: production


### PR DESCRIPTION
Updated the owner to the actual one: `partner-enablement-and-apps`.
Fixes #321 