### PR TITLE
Added a "repository" field to a package.json element's template

### DIFF
--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tradeshift/elements.popover",
   "version": "0.19.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/popover"
+  },
   "main": "lib/popover.umd.js",
   "module": "lib/popover.esm.js",
   "browser": "lib/popover.umd.js",

--- a/plop-templates/components/{{kebabCase name}}/package.json
+++ b/plop-templates/components/{{kebabCase name}}/package.json
@@ -1,14 +1,19 @@
 {
   "name": "@tradeshift/elements.{{kebabCase name}}",
   "version": "{{version}}",
-  "src": "src/{{kebabCase name}}.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/{{kebabCase name}}"
+  },
   "main": "lib/{{kebabCase name}}.umd.js",
-  "browser": "lib/{{kebabCase name}}.umd.js",
   "module": "lib/{{kebabCase name}}.esm.js",
+  "browser": "lib/{{kebabCase name}}.umd.js",
   "files": [
     "lib/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^{{version}}"
-  }
+  },
+  "src": "src/{{kebabCase name}}.js"
 }


### PR DESCRIPTION
I think this field is required for publishing to the Github npm registry. I forgot to add it to a new `popover` element and publishing failed on this component.
Added this field to `popover` + added it to a package.json template so next components will have it from the beginning.