### PR TITLE
fix: Make tooltip position consistent from the anchor

### DIFF
--- a/packages/components/tooltip/src/tooltip.css
+++ b/packages/components/tooltip/src/tooltip.css
@@ -34,20 +34,20 @@
 :host([position='right']) {
 	&::before {
 		bottom: calc(50% - var(--ts-unit));
-		left: 115%;
+		left: calc(100% + var(--ts-unit-half));
 	}
 }
 
 :host([position='left']) {
 	&::before {
 		bottom: calc(50% - var(--ts-unit));
-		right: 115%;
+		right: calc(100% + var(--ts-unit-half));
 	}
 }
 
 :host([position='top']) {
 	&::before {
-		bottom: 115%;
+		bottom: calc(100% + var(--ts-unit-half));
 		left: 50%;
 		transform: translate(-50%, 0);
 	}
@@ -55,7 +55,7 @@
 
 :host([position='bottom']) {
 	&::before {
-		top: 115%;
+		top: calc(100% + var(--ts-unit-half));
 		left: 50%;
 		transform: translate(-50%, 0);
 	}


### PR DESCRIPTION
Position of the tooltip has to be consistent and not relative to the content of the child. Based on the design, it has to be 10px away from the anchor, in all positions.
https://www.figma.com/file/GIQREuPZ2iGA1kRpjlpehT/UI-Components?node-id=1610%3A35588