### PR TITLE
Fix: confirmation prompt reopening issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5694,274 +5694,274 @@
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.cover": "^0.25.0",
-        "@tradeshift/elements.spinner": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.cover": "^0.26.0",
+        "@tradeshift/elements.spinner": "^0.26.0"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.confirmation-prompt": {
       "version": "file:packages/components/confirmation-prompt",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.modal": "^0.25.0",
-        "@tradeshift/elements.text-field": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.modal": "^0.26.0",
+        "@tradeshift/elements.text-field": "^0.26.0"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.dialog": {
       "version": "file:packages/components/dialog",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.button-group": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.modal": "^0.25.0",
-        "@tradeshift/elements.typography": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.button-group": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.modal": "^0.26.0",
+        "@tradeshift/elements.typography": "^0.26.0"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.card": "^0.25.0",
-        "@tradeshift/elements.file-size": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.progress-bar": "^0.25.0",
-        "@tradeshift/elements.typography": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.card": "^0.26.0",
+        "@tradeshift/elements.file-size": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.progress-bar": "^0.26.0",
+        "@tradeshift/elements.typography": "^0.26.0"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.typography": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.typography": "^0.26.0"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.help-text": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.help-text": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.app-icon": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.app-icon": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.typography": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.typography": "^0.26.0"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.cover": "^0.25.0",
-        "@tradeshift/elements.header": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.cover": "^0.26.0",
+        "@tradeshift/elements.header": "^0.26.0"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.tooltip": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.tooltip": "^0.26.0"
       }
     },
     "@tradeshift/elements.popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.radio": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.radio": "^0.26.0"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0"
       }
     },
     "@tradeshift/elements.select": {
       "version": "file:packages/components/select",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.button": "^0.25.0",
-        "@tradeshift/elements.button-group": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.list-item": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.button": "^0.26.0",
+        "@tradeshift/elements.button-group": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.list-item": "^0.26.0"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.icon": "^0.25.0",
-        "@tradeshift/elements.tab": "^0.25.0",
-        "@tradeshift/elements.typography": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.icon": "^0.26.0",
+        "@tradeshift/elements.tab": "^0.26.0",
+        "@tradeshift/elements.typography": "^0.26.0"
       }
     },
     "@tradeshift/elements.text-field": {
       "version": "file:packages/components/text-field",
       "requires": {
-        "@tradeshift/elements": "^0.25.0",
-        "@tradeshift/elements.help-text": "^0.25.0",
-        "@tradeshift/elements.input": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0",
+        "@tradeshift/elements.help-text": "^0.26.0",
+        "@tradeshift/elements.input": "^0.26.0"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.25.0"
+        "@tradeshift/elements": "^0.26.0"
       }
     },
     "@types/braces": {

--- a/packages/components/confirmation-prompt/src/confirmation-prompt.js
+++ b/packages/components/confirmation-prompt/src/confirmation-prompt.js
@@ -94,7 +94,7 @@ export class TSConfirmationPrompt extends TSElement {
 				?data-visible=${this.visible}
 				data-size="medium"
 				data-title="${this.header || ''}"
-				@close="${this.onClose}"
+				@closed="${this.onClose}"
 			>
 				<div class="content" slot="main">
 					<h2>

--- a/packages/components/modal/src/modal.js
+++ b/packages/components/modal/src/modal.js
@@ -67,6 +67,10 @@ export class TSModal extends TSElement {
 
 	close() {
 		this.visible = false;
+		/**
+		 * Emitted on start of the modal closing
+		 */
+		this.dispatchCustomEvent('close');
 	}
 
 	handleTransition(e) {
@@ -96,11 +100,6 @@ export class TSModal extends TSElement {
 			 * Emitted on start of the modal opening
 			 */
 			this.dispatchCustomEvent('open');
-		} else {
-			/**
-			 * Emitted on start of the modal closing
-			 */
-			this.dispatchCustomEvent('close');
 		}
 	}
 


### PR DESCRIPTION
The confirmation prompt couldn't get reopened because of an issue with modal close event which was emitting on `data-visible` prop change, that wasn't the correct way to handle it. Moved the close event of the modal to close method to just be emitted on deliberate actions of user for dismissing the modal. 
In the confirmation prompt knowing when the modal gets `closed` is enough.