### PR TITLE
ci: change npm token used at publish step to a specially created for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Publish to NPM
         run: npm run lerna-publish-ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PUBLIC }}
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
 Change npm token used at publish step to a specially created for publish and release purposes.