### PR TITLE
PEAA-360: add a action-select component to the library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6621,6 +6621,15 @@
         "lit-element": "^2.4.0"
       }
     },
+    "@tradeshift/elements.action-select": {
+      "version": "file:packages/components/action-select",
+      "requires": {
+        "@tradeshift/elements": "^0.27.6",
+        "@tradeshift/elements.icon": "^0.27.6",
+        "@tradeshift/elements.overlay": "^0.27.6",
+        "@tradeshift/elements.select-menu": "^0.27.6"
+      }
+    },
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "file:packages/core",
+    "@tradeshift/elements.action-select": "file:packages/components/action-select",
     "@tradeshift/elements.app-icon": "file:packages/components/app-icon",
     "@tradeshift/elements.aside": "file:packages/components/aside",
     "@tradeshift/elements.basic-table": "file:packages/components/basic-table",

--- a/packages/components/action-select/README.md
+++ b/packages/components/action-select/README.md
@@ -1,0 +1,158 @@
+<h1 align="center">
+    <a href="https://tradeshift.com/">
+      <img alt="Tradeshift" src="https://tradeshift.com/wp-content/themes/Tradeshift/img/brand/logo-black.png"/>
+    </a>
+</h1>
+
+<h1 align="center">Elements - action-select</h1>
+
+<p align="center">
+  Part of the reusable Tradeshift UI Components as Web Components.
+    <a href="https://tradeshift.github.io/elements/?path=/story/ts-action-select--default">
+      Demo
+    </a>
+</p>
+
+<p align="center">
+    <a href="https://www.npmjs.com/package/@tradeshift/elements.action-select">
+      <img alt="NPM Version" src="https://badgen.net/npm/v/@tradeshift/elements.action-select" height="20"/>
+    </a>
+    <a href="https://npmcharts.com/compare/@tradeshift/elements.action-select?minimal=true">
+		  <img alt="Downloads per month" src="https://badgen.net/npm/dm/@tradeshift/elements.action-select" height="20"/>
+		</a>
+		<a href="https://www.npmjs.com/browse/depended/@tradeshift/elements.action-select">
+		  <img alt="Dependent packages" src="https://badgen.net/npm/dependents/@tradeshift/elements.action-select" height="20"/>
+		</a>
+</p>
+
+<style>
+  table {
+        width:100%;
+  }
+</style>
+
+## ➤ Properties
+
+| Property | Attribute | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
+| disabled | disabled | Boolean | false | Is component disabled or not. |
+| opened | opened | Boolean | false | Is the action select opened or not |
+| items | items | Array |  | Array of action items. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon |
+
+## ➤ Slots
+
+| Name    | Description                                                                                         |
+| ------- | --------------------------------------------------------------------------------------------------- |
+| default | Element in this slot becomes the anchor for the action menu. When empty, it will render a menu icon |
+
+## ➤ Events
+
+| Name                | Description                          | Payload      |
+| ------------------- | ------------------------------------ | ------------ |
+| action-select-click | Emitted when user clicks on the item | { selected } |
+
+## ➤ How to use it
+
+- Install the package of actionSelect
+
+```shell
+$ npm i @tradeshift/elements.action-select --save
+```
+
+- Import the component
+
+```js
+import '@tradeshift/elements.action-select';
+```
+
+or
+
+```html
+<script src="node_modules/@tradeshift/elements.action-select/lib/action-select.umd.js"></script>
+```
+
+- Use it like [demo]("https://tradeshift.github.io/elements/?path=/story/ts-action-select--default")
+
+- Our components rely on having the `Open Sans` available, You can see the `font-weight` and `font-style` you need to load [here](https://github.com/Tradeshift/elements/blob/master/packages/core/src/fonts.css), or you can just load it from our package (for now)
+
+```html
+<link rel="stylesheet" href="node_modules/@tradeshift/elements/src/fonts.css" />
+```
+
+## ➤ Polyfills
+
+For supporting IE11 you need to add couple of things
+
+- Don't shim CSS Custom Properties in IE11
+
+```html
+<!-- Place this in the <head>, before the Web Component polyfills are loaded -->
+<script>
+	if (!window.Promise) {
+		window.ShadyCSS = { nativeCss: true };
+	}
+</script>
+```
+
+##### You have two options for polyfills library:
+
+1. Use [`@open-wc/polyfills-loader`](https://github.com/open-wc/open-wc/tree/master/packages/polyfills-loader)
+
+- Installation
+
+```shell
+$ npm i @open-wc/polyfills-loader
+```
+
+- Load it
+
+```js
+import loadPolyfills from '@open-wc/polyfills-loader';
+
+loadPolyfills().then(() => import('./my-app.js'));
+```
+
+2. Use [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs)
+
+- Installation
+
+```hell
+$ npm i @webcomponents/webcomponentsjs --save
+```
+
+- Enable ES5 class-less Custom Elements
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+```
+
+- Load appropriate polyfills and shims with [`@webcomponents/webcomponentsjs`](https://github.com/webcomponents/webcomponentsjs)
+
+```html
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+```
+
+## ➤ How to contribute
+
+Thanks for your interest and help!
+
+- First thing you need to do is read this [[Component Checklist](https://github.com/Tradeshift/elements/wiki/Component-checklist)] which contains lots of important information about what you need to consider when you are creating/changing components
+
+##### [General info](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter)
+
+You can find some [links to useful materials](https://github.com/Tradeshift/elements/wiki/Useful-materials-starter) about what we are using and some tutorials and articles that can help you get started.
+
+## ➤ [Polyfill Limitations](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+You can see a list of limitations that we should watch out for, [here](https://github.com/Tradeshift/elements/wiki/Polyfill-Limitations)
+
+## ➤ License
+
+- You can always create forks on GitHub, submit Issues and Pull Requests.
+- You can only use Tradeshift Elements to make apps on a Tradeshift platform, e.g. tradeshift.com.
+- You can fix a bug until the bugfix is deployed by Tradeshift.
+- You can host Tradeshift Elements yourself.
+- If you want to make a bigger change or just want to talk with us, reach out to our team here on GitHub.
+
+You can read the full license agreement in the [LICENSE.md](https://github.com/Tradeshift/elements/blob/master/LICENSE.md).

--- a/packages/components/action-select/package.json
+++ b/packages/components/action-select/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tradeshift/elements.action-select",
+  "version": "0.27.6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tradeshift/elements.git",
+    "directory": "packages/components/action-select"
+  },
+  "main": "lib/action-select.umd.js",
+  "module": "lib/action-select.esm.js",
+  "browser": "lib/action-select.umd.js",
+  "files": [
+    "lib/*"
+  ],
+  "dependencies": {
+    "@tradeshift/elements": "^0.27.6",
+    "@tradeshift/elements.icon": "^0.27.6",
+    "@tradeshift/elements.overlay": "^0.27.6",
+    "@tradeshift/elements.select-menu": "^0.27.6"
+  },
+  "src": "src/action-select.js"
+}

--- a/packages/components/action-select/src/action-select.css
+++ b/packages/components/action-select/src/action-select.css
@@ -1,0 +1,7 @@
+#container {
+	background-color: var(--ts-color-white);
+	display: flex;
+	& ts-icon {
+		cursor: pointer;
+	}
+}

--- a/packages/components/action-select/src/action-select.js
+++ b/packages/components/action-select/src/action-select.js
@@ -1,0 +1,155 @@
+import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import '@tradeshift/elements.icon';
+// eslint-disable-next-line import/no-duplicates
+import '@tradeshift/elements.overlay';
+// eslint-disable-next-line import/no-duplicates
+import { TSOverlay } from '@tradeshift/elements.overlay';
+import '@tradeshift/elements.select-menu';
+import css from './action-select.css';
+
+export class TSActionSelect extends TSElement {
+	static get styles() {
+		return [TSElement.styles, unsafeCSS(css)];
+	}
+
+	static get properties() {
+		return {
+			/** Direction of the component 'rtl' or 'ltr'. */
+			dir: { type: String, reflect: true },
+			/** Is component disabled or not. */
+			disabled: { type: Boolean, reflect: true },
+			/** Is the action select opened or not */
+			opened: { type: Boolean, reflect: true },
+			/** Array of action items. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon */
+			items: { type: Array, reflect: true }
+		};
+	}
+
+	constructor() {
+		super();
+		this.opened = false;
+	}
+
+	toggle() {
+		this.opened = !this.opened;
+	}
+
+	/** @private */
+	menuClick() {
+		this.toggle();
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeOverlay();
+	}
+
+	attributeChangedCallback(name, oldVal, newVal) {
+		super.attributeChangedCallback(name, oldVal, newVal);
+		switch (name) {
+			case 'opened':
+				if (newVal === null) {
+					this.removeOverlay();
+				} else {
+					window.customElements.whenDefined('ts-action-select').then(() => {
+						this.addOverlay();
+					});
+				}
+				break;
+
+			default:
+			// do nothing
+		}
+	}
+
+	/** @private */
+	addOverlay() {
+		const container = this.renderRoot.getElementById('container');
+		if (!container) {
+			return;
+		}
+
+		const slot = this.renderRoot.querySelector('slot');
+		const childElements = Array.prototype.filter.call(
+			slot.assignedNodes({ flatten: true }),
+			node => node.nodeType === Node.ELEMENT_NODE
+		);
+		const anchor = childElements[0];
+		if (!anchor) {
+			return;
+		}
+		const dropout = this.renderRoot.getElementById('dropout');
+		if (!dropout) {
+			return;
+		}
+
+		this.closeOverlay = TSOverlay.open(dropout, anchor);
+	}
+
+	/** @private */
+	removeOverlay() {
+		if (this.closeOverlay) {
+			this.closeOverlay();
+		}
+	}
+
+	/**
+	 * Updates the current selection and dispatches 'select-changed' event if component is in single selection mode.
+	 * @private
+	 * @param {Event} event
+	 */
+	handleSelection(event) {
+		if (this.disabled) {
+			return;
+		}
+		event.stopPropagation();
+		const item = event.target;
+		const itemId = item['item-id'];
+		/**
+		 * Emitted when user clicks on the item
+		 * @payload { selected }
+		 */
+		this.dispatchCustomEvent('action-select-click', { selected: itemId });
+		this.opened = false;
+	}
+
+	/** @private */
+	get dropout() {
+		return html`
+			<ts-overlay id="dropout" autoWidth .dir="${this.dir}" @overlay-close=${this.onOverlayCloseListener}>
+				<ts-select-menu
+					.items="${this.items}"
+					.dir="${this.dir}"
+					?disabled="${this.disabled}"
+					@select-menu-changed=${this.handleSelection}
+				></ts-select-menu>
+			</ts-overlay>
+		`;
+	}
+
+	/** @private */
+	onOverlayCloseListener() {
+		this.opened = false;
+	}
+
+	render() {
+		return html`
+			<div id="container">
+				<div @click="${this.menuClick}" style="position: relative;">
+					<!-- Element in this slot becomes the anchor for the action menu. When empty, it will render a menu icon -->
+					<slot>
+						<ts-icon
+							icon="more"
+							size="large"
+							type="${this.disabled ? 'disabled' : 'gray-darker'}"
+							?disabled="${this.disabled}"
+						></ts-icon>
+					</slot>
+					${this.opened ? this.dropout : ''}
+				</div>
+			</div>
+		`;
+	}
+}
+
+customElementDefineHelper('ts-action-select', TSActionSelect);

--- a/packages/components/action-select/stories/action-select.happo.js
+++ b/packages/components/action-select/stories/action-select.happo.js
@@ -1,0 +1,56 @@
+import { html } from 'lit-html';
+import '@tradeshift/elements';
+import '@tradeshift/elements.action-select';
+
+export default {
+	title: 'ts-action-select'
+};
+
+const items = [
+	{ id: 1, title: 'option one' },
+	{ id: 2, title: 'option two' },
+	{ id: 3, title: 'option three' }
+];
+
+const itemsWithIcons = [
+	{ id: 1, title: 'option one', icon: 'ada' },
+	{ id: 2, title: 'option two', icon: 'apps' },
+	{ id: 3, title: 'option three', icon: 'company-profile' }
+];
+
+export const TestSingleSelect = () => {
+	return html`
+		<style>
+			.render-block {
+				flex: 0 0 19%;
+				height: 400px;
+			}
+		</style>
+		<div style="display: flex; flex-flow: row wrap; justify-content: space-between;">
+			<div class="render-block">
+				<p>Simple action select</p>
+				<ts-action-select opened .items="${items}"></ts-action-select>
+			</div>
+
+			<div class="render-block">
+				<p>Action select with custom anchor</p>
+				<ts-action-select opened .items="${items}"><button>Button</button></ts-action-select>
+			</div>
+
+			<div class="render-block">
+				<p>Disabled action select</p>
+				<ts-action-select opened .items="${items}" disabled></ts-action-select>
+			</div>
+
+			<div class="render-block">
+				<p>RTL Action select with icons</p>
+				<ts-action-select opened .items="${itemsWithIcons}" dir="rtl"></ts-action-select>
+			</div>
+
+			<div class="render-block">
+				<p>Action select with icons</p>
+				<ts-action-select opened .items="${itemsWithIcons}"></ts-action-select>
+			</div>
+		</div>
+	`;
+};

--- a/packages/components/action-select/stories/action-select.stories.js
+++ b/packages/components/action-select/stories/action-select.stories.js
@@ -1,0 +1,194 @@
+import { html } from 'lit-html';
+import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+import '@tradeshift/elements.action-select';
+import '@tradeshift/elements.button';
+import '@tradeshift/elements.icon';
+import readme from '../README.md';
+
+export default {
+	title: 'ts-action-select',
+	decorators: [withKnobs]
+};
+
+const items = [
+	{ id: 0, title: 'Action Select Item 1' },
+	{ id: 1, title: 'Another Action Item 2' },
+	{ id: 2, title: 'Some Item on place number 3' },
+	{ id: 3, title: 'How many items do we suport?' },
+	{ id: 4, title: 'Apparently, more than 5' },
+	{ id: 5, title: 'Can it fit item 6?' },
+	{ id: 6, title: "Let's try to add item 7" },
+	{ id: 7, title: 'What about Item 8?' },
+	{ id: 8, title: 'There is definitely a place for Item 9' },
+	{ id: 9, title: 'How many items are here?' },
+	{ id: 10, title: 'We need more items!' },
+	{ id: 11, title: 'More! More! More!' },
+	{ id: 12, title: 'Items! Items! Items!' },
+	{ id: 13, title: 'Actions! Actions! Actions!' },
+	{ id: 14, title: 'We need to overflow it!' },
+	{ id: 15, title: 'Finaly we overflow it' },
+	{ id: 16, title: 'Just one more item here' }
+];
+
+export const Default = () => {
+	const dir = select(
+		'dir',
+		{
+			ltr: 'ltr',
+			rtl: 'rtl'
+		},
+		'ltr'
+	);
+	const disabled = boolean('disabled', false);
+	const opened = boolean('opened', false);
+	const withIcons = boolean('with icons', false);
+
+	const actionItems = [...items];
+	if (withIcons) {
+		for (const item of actionItems) {
+			item.icon = 'company-profile';
+		}
+	}
+
+	return html`
+		<div style="margin: 150px;">
+			<ts-action-select
+				.dir="${dir}"
+				?disabled="${disabled}"
+				?opened="${opened}"
+				.items="${actionItems.splice(0, 3)}"
+				@action-select-click="${action('Action item selected')}"
+			></ts-action-select>
+		</div>
+	`;
+};
+
+Default.story = {
+	name: 'default',
+	parameters: { notes: readme }
+};
+
+export const Corner = () => {
+	const dir = select(
+		'dir',
+		{
+			ltr: 'ltr',
+			rtl: 'rtl'
+		},
+		'ltr'
+	);
+	const withIcons = boolean('with icons', false);
+
+	const actionItems = [...items];
+	if (withIcons) {
+		for (const item of actionItems) {
+			item.icon = 'company-profile';
+		}
+	}
+
+	return html`
+		<div style="position: absolute; top: 20px; left: 20px;">
+			<span>Opens to bottom right</span>
+			<ts-action-select
+				.dir="${dir}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			></ts-action-select>
+		</div>
+		<div style="position: absolute; top: 20px; right: 20px;">
+			Opens to bottom left
+			<ts-action-select
+				.dir="${dir}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			></ts-action-select>
+		</div>
+		<div style="position: absolute; bottom: 20px; left: 20px;">
+			Opens to top right
+			<ts-action-select
+				.dir="${dir}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			></ts-action-select>
+		</div>
+		<div style="position: absolute; bottom: 20px; right: 20px;">
+			<span>Opens to top left</span>
+			<ts-action-select
+				.dir="${dir}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			></ts-action-select>
+		</div>
+	`;
+};
+
+Corner.story = {
+	name: 'behaviour in corners',
+	parameters: { notes: readme }
+};
+
+export const Triggers = () => {
+	const dir = select(
+		'dir',
+		{
+			ltr: 'ltr',
+			rtl: 'rtl'
+		},
+		'ltr'
+	);
+	const disabled = boolean('disabled', false);
+	const withIcons = boolean('with icons', false);
+
+	const actionItems = [...items];
+	if (withIcons) {
+		for (const item of actionItems) {
+			item.icon = 'company-profile';
+		}
+	}
+
+	return html`
+			<ts-action-select
+				.dir="${dir}"
+				?disabled="${disabled}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			>
+			<ts-button type="primary">Show action menu</ts-button>
+		</ts-action-select>
+		<br />
+			<ts-action-select
+				.dir="${dir}"
+				?disabled="${disabled}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			>
+			<ts-button type="text">Text button</ts-button>
+			</ts-action-select>
+			<br />
+			<ts-action-select
+				.dir="${dir}"
+				?disabled="${disabled}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			>
+			<ts-button icon="ada"></ts-button>
+		</ts-action-select>
+		<br />
+			<ts-action-select
+				.dir="${dir}"
+				?disabled="${disabled}"
+				.items="${actionItems}"
+				@action-select-click="${action('Action item selected')}"
+			>
+			<ts-icon icon="all-documents" size="large" type="gray-darker" style="cursor:pointer;"></ts-icon>
+		</ts-action-select>
+		</div>
+	`;
+};
+
+Triggers.story = {
+	name: 'different types of triggers',
+	parameters: { notes: readme }
+};

--- a/packages/components/icon/src/assets/icons/index.js
+++ b/packages/components/icon/src/assets/icons/index.js
@@ -37,6 +37,7 @@ import preview from './preview.svg';
 import send from './send.svg';
 import associated from './associated.svg';
 import companyProfile from './company-profile.svg';
+import more from './more.svg';
 
 const icons = {
 	remove,
@@ -63,6 +64,7 @@ const icons = {
 	preview,
 	send,
 	associated,
+	more,
 	'company-size': companySize,
 	'insert-from-inventory': insertFromInventory,
 	'all-documents': allDocuments,

--- a/packages/components/icon/src/assets/icons/more.svg
+++ b/packages/components/icon/src/assets/icons/more.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle cx="6" cy="12" r="2" fill="currentColor" fill-rule="evenodd" /><circle cx="12" cy="12" r="2" fill="currentColor" fill-rule="evenodd" /><circle cx="18" cy="12" r="2" fill="currentColor" fill-rule="evenodd" /></svg>

--- a/rollup.globals.json
+++ b/rollup.globals.json
@@ -1,5 +1,6 @@
 {
 	"@tradeshift/elements": "ts.elements",
+	"@tradeshift/elements.action-select": "ts.elements.action-select",
 	"@tradeshift/elements.app-icon": "ts.elements.app-icon",
 	"@tradeshift/elements.aside": "ts.elements.aside",
 	"@tradeshift/elements.board": "ts.elements.board",


### PR DESCRIPTION

Added a new component, `action-select` that will show a dropdown menu of actions bounded to the provided anchor element. This anchor element should be inside the default slot, otherwise the default ts-icon with icon `more` will be rendered.
Example of usage with anchor element (in this case it is a `ts-button`): 
```html
<ts-action-select>
  <ts-button>Button</ts-button>
</ts-action-select>
```

Also, added a new icon called `more` that looks like `...` and is similar to the icon `ts-icon-other` from Tradeshift-UI.