### PR TITLE
fix(select): no-apply-button attribute wrongly set on select-menu

### DIFF
--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -235,7 +235,7 @@ export class TSSelect extends TSElement {
 								.dir="${this.dir}"
 								?disabled="${this.disabled}"
 								?multiselect="${this.multiselect}"
-								?noApplyButton="${this.noApplyButton}"
+								?no-apply-button="${this.noApplyButton}"
 								.filterValue="${this.filterValue}"
 								.currentSelection="${[...this.selected]}"
 								@select-menu-changed=${this.onChangeListener}

--- a/packages/components/select/stories/select.stories.js
+++ b/packages/components/select/stories/select.stories.js
@@ -53,7 +53,7 @@ export const Default = () => {
 				?disabled="${disabled}"
 				?opened="${opened}"
 				?multiselect="${multiselect}"
-				?noApplyButton="${noApplyButton}"
+				?no-apply-button="${noApplyButton}"
 				.placeholder="${placeholder}"
 				.selected="${selected}"
 				.items="${selectItems}"


### PR DESCRIPTION
when changed the attribute to snake case no-apply-button, it was
not propagated correctly to the select-menu used in the select

see also: PDV-1407