### PR TITLE
feat: [PEAA-851] add an autogeneration of types for elements

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run update-readme && npm run format && npx lint-staged && npm run check-deps
+npm run update-readme && npm run generate-types && npm run format && npx lint-staged && npm run check-deps

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lerna-version": "lerna version --conventional-commits --yes --no-push",
     "lint": "cross-env-shell eslint --config `pwd`/.eslintrc --color \"packages/**/**/{src,stories}/**/*.js\"",
     "new-version": "sh ./scripts/new-version.sh",
-    "preversion": "run-s update-doc-src-from-readme update-readme format",
+    "preversion": "run-s update-doc-src-from-readme update-readme generate-types format",
     "server": "npx http-server",
     "server-reload": "reload --browser --exts html,umd.js",
     "stage": "lint-staged",
@@ -68,6 +68,7 @@
     "update-doc-src-from-readme": "cross-env-shell node ./scripts/from-readme/index.js",
     "update-readme": "cross-env-shell node ./scripts/update-readme-files.js",
     "add-desc-to-src": "cross-env-shell node ./scripts/add-description-to-src.js",
+    "generate-types": "cross-env-shell node ./scripts/generate-types.js",
     "watch": "cross-env-shell lerna exec --parallel -- rollup -w -c=`pwd`/rollup.config.js",
     "prepare": "husky install"
   },

--- a/packages/components/action-select/types/action-select.d.ts
+++ b/packages/components/action-select/types/action-select.d.ts
@@ -1,0 +1,29 @@
+export interface TSActionSelectHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  Is component disabled or not.  */
+	disabled?: boolean;
+
+	/**  Is the action select opened or not  */
+	opened?: boolean;
+
+	/**  Array of action items. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
+	items?: [];
+
+}
+
+export interface TSActionSelect {
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  Is component disabled or not.  */
+	disabled?: boolean;
+
+	/**  Is the action select opened or not  */
+	opened?: boolean;
+
+	/**  Array of action items. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
+	items?: [];
+
+}

--- a/packages/components/app-icon/types/app-icon.d.ts
+++ b/packages/components/app-icon/types/app-icon.d.ts
@@ -1,5 +1,23 @@
-export declare class TSIcon {
-	size?: '' | 'large';
+export interface TSAppIconHTMLAttributes {
+	/**  Size of the app icon, available variants: ''(default), 'large'  */
+	size?: string;
+
+	/**  Specifies the URL of an image  */
 	src?: string;
+
+	/**  Specifies an alternate text for an image  */
 	alt?: string;
+
+}
+
+export interface TSAppIcon {
+	/**  Size of the app icon, available variants: ''(default), 'large'  */
+	size?: string;
+
+	/**  Specifies the URL of an image  */
+	src?: string;
+
+	/**  Specifies an alternate text for an image  */
+	alt?: string;
+
 }

--- a/packages/components/aside/types/aside.d.ts
+++ b/packages/components/aside/types/aside.d.ts
@@ -1,9 +1,35 @@
-export declare class TSAside {
-	dir?: 'rtl' | 'ltr' | 'auto';
-	'data-title'?: string;
-	'data-visible'?: boolean;
-	'data-busy'?: string;
-	'no-close-on-esc-key'?: boolean;
-	hasFoot?: boolean;
-	hasPlatformObject?: boolean;
+export interface TSAsideHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Aside header title  */
+	"data-title"?: string;
+
+	/**  Show/hide aside  */
+	"data-visible"?: boolean;
+
+	/**  If it exist as an attribute, the aside would show a spinner in it with the provided value of this attribute as the message of it  */
+	"data-busy"?: string;
+
+	/**  Disable closing the aside with escape key  */
+	"no-close-on-esc-key"?: boolean;
+
+}
+
+export interface TSAside {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Aside header title  */
+	title?: string;
+
+	/**  Show/hide aside  */
+	visible?: boolean;
+
+	/**  If it exist as an attribute, the aside would show a spinner in it with the provided value of this attribute as the message of it  */
+	busy?: string;
+
+	/**  Disable closing the aside with escape key  */
+	noCloseOnEscKey?: boolean;
+
 }

--- a/packages/components/basic-table/types/basic-table.d.ts
+++ b/packages/components/basic-table/types/basic-table.d.ts
@@ -1,6 +1,29 @@
-export declare class TSBasicTable {
-	dir?: 'rtl' | 'ltr' | 'auto';
-	cols: any[];
-	data: any[];
-	selectedIds?: any[];
+export interface TSBasicTableHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  <br> List of columns configs, including: <br> - property: Property key of the column in data object, <br> - value: value of the title of column', <br> - visibility?: Which screen sizes this column should be visible -> 'always-visible'(default) or 'desktop-only' or 'mobile-only', <br> - size?: 'small' or 'medium' or 'large', <br> - display?: 'left' or 'right' or 'center', <br> - renderer?: you can pass a renderer function to customize the content of the cells in this column, args: (cellValue, rowObject) <br>  */
+	cols?: [];
+
+	/**  List of selected rows ids (caveat: the row should include id property)   */
+	selectedIds?: [];
+
+	/**  List of rows data objects  */
+	data?: [];
+
+}
+
+export interface TSBasicTable {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  <br> List of columns configs, including: <br> - property: Property key of the column in data object, <br> - value: value of the title of column', <br> - visibility?: Which screen sizes this column should be visible -> 'always-visible'(default) or 'desktop-only' or 'mobile-only', <br> - size?: 'small' or 'medium' or 'large', <br> - display?: 'left' or 'right' or 'center', <br> - renderer?: you can pass a renderer function to customize the content of the cells in this column, args: (cellValue, rowObject) <br>  */
+	cols?: [];
+
+	/**  List of selected rows ids (caveat: the row should include id property)   */
+	selectedIds?: [];
+
+	/**  List of rows data objects  */
+	data?: [];
+
 }

--- a/packages/components/board/types/board.d.ts
+++ b/packages/components/board/types/board.d.ts
@@ -1,4 +1,17 @@
-export declare class TSBoard {
-	dir?: 'rtl' | 'ltr' | 'auto';
-	'data-title'?: string;
+export interface TSBoardHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Board header title  */
+	"data-title"?: string;
+
+}
+
+export interface TSBoard {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Board header title  */
+	title?: string;
+
 }

--- a/packages/components/button-group/types/button-group.d.ts
+++ b/packages/components/button-group/types/button-group.d.ts
@@ -1,1 +1,5 @@
-export declare class TSButtonGroup {}
+export interface TSButtonGroupHTMLAttributes {
+}
+
+export interface TSButtonGroup {
+}

--- a/packages/components/button/types/button.d.ts
+++ b/packages/components/button/types/button.d.ts
@@ -1,13 +1,59 @@
-import { sizes, types } from './utils';
+export interface TSButtonHTMLAttributes {
+	/**  Button type to have different style `primary`, `secondary`, `text`, `accept`, `warning`, `danger`  */
+	type?: string;
 
-export declare class TSButton {
-	type?: types;
-	size?: sizes;
+	/**  Size of the button, `macro`, `micro`  */
+	size?: string;
+
+	/**  Show busy/loading animation  */
 	busy?: boolean;
+
+	/**  Icon name, see the list of available icons in ts-icon component. Also note that it will hide the slot content unless the type is text  */
 	icon?: string;
+
+	/**  Determine if the button is disabled. `button-click` event won't be dispatched  */
 	disabled?: boolean;
+
+	/**  For internal use in `ts-button-group` component  */
 	grouped?: boolean;
-	dir?: 'rtl' | 'ltr' | 'auto';
+
+	/**  Make the button focused  */
+	focused?: boolean;
+
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Make the button take the full width of the container  */
+	"full-width"?: boolean;
+
 }
 
-export { sizes, types } from './utils';
+export interface TSButton {
+	/**  Button type to have different style `primary`, `secondary`, `text`, `accept`, `warning`, `danger`  */
+	type?: string;
+
+	/**  Size of the button, `macro`, `micro`  */
+	size?: string;
+
+	/**  Show busy/loading animation  */
+	busy?: boolean;
+
+	/**  Icon name, see the list of available icons in ts-icon component. Also note that it will hide the slot content unless the type is text  */
+	icon?: string;
+
+	/**  Determine if the button is disabled. `button-click` event won't be dispatched  */
+	disabled?: boolean;
+
+	/**  For internal use in `ts-button-group` component  */
+	grouped?: boolean;
+
+	/**  Make the button focused  */
+	focused?: boolean;
+
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Make the button take the full width of the container  */
+	fullWidth?: boolean;
+
+}

--- a/packages/components/card/types/card.d.ts
+++ b/packages/components/card/types/card.d.ts
@@ -1,9 +1,33 @@
-export declare class TSCard {
+export interface TSCardHTMLAttributes {
 	type?: string;
+
 	orientation?: string;
+
 	rtl?: boolean;
+
 	size?: string;
-	'no-padding'?: boolean;
-	'no-horizontal-padding'?: boolean;
-	'no-vertical-padding'?: boolean;
+
+	"no-padding"?: boolean;
+
+	"no-horizontal-padding"?: boolean;
+
+	"no-vertical-padding"?: boolean;
+
+}
+
+export interface TSCard {
+	type?: string;
+
+	orientation?: string;
+
+	rtl?: boolean;
+
+	size?: string;
+
+	noPadding?: boolean;
+
+	noHorizontalPadding?: boolean;
+
+	noVerticalPadding?: boolean;
+
 }

--- a/packages/components/checkbox/types/checkbox.d.ts
+++ b/packages/components/checkbox/types/checkbox.d.ts
@@ -1,8 +1,47 @@
-export declare class TSCheckbox {
+export interface TSCheckboxHTMLAttributes {
+	/**  Name of checkbox  */
 	name?: string;
+
+	/**  Value of checkbox  */
 	value?: string;
-	dir?: 'rtl' | 'ltr' | 'auto';
-	'data-label'?: string;
+
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Label of checkbox. To customize the label and have something more than simple string, use the slot, and remove this attribute  */
+	"data-label"?: string;
+
+	/**  Status of checkbox  */
 	checked?: boolean;
+
+	/**  disabled  */
 	disabled?: boolean;
+
+	/**  readonly, user can't change the value like disabled, but with different styling  */
+	readonly?: boolean;
+
+}
+
+export interface TSCheckbox {
+	/**  Name of checkbox  */
+	name?: string;
+
+	/**  Value of checkbox  */
+	value?: string;
+
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Label of checkbox. To customize the label and have something more than simple string, use the slot, and remove this attribute  */
+	label?: string;
+
+	/**  Status of checkbox  */
+	checked?: boolean;
+
+	/**  disabled  */
+	disabled?: boolean;
+
+	/**  readonly, user can't change the value like disabled, but with different styling  */
+	readonly?: boolean;
+
 }

--- a/packages/components/confirmation-prompt/types/confirmation-prompt.d.ts
+++ b/packages/components/confirmation-prompt/types/confirmation-prompt.d.ts
@@ -1,0 +1,65 @@
+export interface TSConfirmationPromptHTMLAttributes {
+	/**  Dialog can be toggled by add/removing this attribute  */
+	"data-visible"?: boolean;
+
+	/**  Header of the modal  */
+	"data-header"?: string;
+
+	/**  Title on top of the text part  */
+	"data-title"?: string;
+
+	/**  Text content of the modal  */
+	text?: string;
+
+	/**  Label of the text field component  */
+	"text-field-label"?: string;
+
+	/**  Placeholder of the text field component  */
+	"text-field-placeholder"?: string;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info   */
+	"help-text-messages"?: [];
+
+	/**  If you have more than one help text message, you should pass a title to it. See help-text component for more info   */
+	"help-text-title"?: string;
+
+	/**  Can be used for customizing the buttons text and providing translations for them  */
+	translations?: object;
+
+	/**  Text that the user need to type for confirmation   */
+	"text-to-match"?: string;
+
+}
+
+export interface TSConfirmationPrompt {
+	/**  Dialog can be toggled by add/removing this attribute  */
+	visible?: boolean;
+
+	/**  Header of the modal  */
+	header?: string;
+
+	/**  Title on top of the text part  */
+	title?: string;
+
+	/**  Text content of the modal  */
+	text?: string;
+
+	/**  Label of the text field component  */
+	textFieldLabel?: string;
+
+	/**  Placeholder of the text field component  */
+	textFieldPlaceholder?: string;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info   */
+	helpTextMessages?: [];
+
+	/**  If you have more than one help text message, you should pass a title to it. See help-text component for more info   */
+	helpTextTitle?: string;
+
+	/**  Can be used for customizing the buttons text and providing translations for them  */
+	translations?: object;
+
+	/**  Text that the user need to type for confirmation   */
+	textToMatch?: string;
+
+}

--- a/packages/components/cover/types/cover.d.ts
+++ b/packages/components/cover/types/cover.d.ts
@@ -1,3 +1,9 @@
-export declare class TSCover {
-	'data-visible'?: boolean;
+export interface TSCoverHTMLAttributes {
+	"data-visible"?: boolean;
+
+}
+
+export interface TSCover {
+	visible?: boolean;
+
 }

--- a/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
+++ b/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
@@ -1,0 +1,33 @@
+export interface TSDatePickerOverlayHTMLAttributes {
+	dir?: string;
+
+	translations?: object;
+
+	firstDay?: number;
+
+	pageDate?: string;
+
+	selectedDate?: string;
+
+	required?: boolean;
+
+	disabledDateCheck?: function;
+
+}
+
+export interface TSDatePickerOverlay {
+	dir?: string;
+
+	translations?: object;
+
+	firstDay?: number;
+
+	pageDate?: string;
+
+	selectedDate?: string;
+
+	required?: boolean;
+
+	disabledDateCheck?: function;
+
+}

--- a/packages/components/date-picker/types/date-picker.d.ts
+++ b/packages/components/date-picker/types/date-picker.d.ts
@@ -1,0 +1,125 @@
+export interface TSDatePickerHTMLAttributes {
+	/**  Can be used for customizing placeholder, days abbreviations, months abbreviations and providing translations for them <br> see the structure in its storybook knobs section. <br>  */
+	translations?: object;
+
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  For setting the date of the date picker you can use this prop/attribute. It will get update after the user changes the date.  */
+	"selected-date"?: string;
+
+	/**  This date can be used as a way to customize the month that date picker dropdown will be opened in, <br>  by default it's the current month. You can pass any date in the preferred month.  */
+	"page-date"?: string;
+
+	/**  Label of the date picker.  */
+	label?: string;
+
+	/**  Is the date picker disabled?  */
+	disabled?: boolean;
+
+	/**  Is the date picker readonly?  */
+	readonly?: boolean;
+
+	/**  You can pass a function to this prop, which will get js Date object of the days in the calendar view as input, <br>  and expect a boolean to make the day disabled or not.  */
+	isDisabledDate?: function;
+
+	/**  Minimum date which can be selected by the user. Dates before this will be shown as disabled. Supports ISO 8601 format  */
+	min?: string;
+
+	/**  Maximum date which can be selected by the user. Dates after this will be shown as disabled. Supports ISO 8601 format  */
+	max?: string;
+
+	/**  Is the dropdown part opened or not?  */
+	opened?: boolean;
+
+	/**  Disable the typing a new date  */
+	"not-typeable"?: boolean;
+
+	/**  Which day should be shown as the first day of the week. A number between 0-6 (0 = Sunday, 6 = Saturday)  */
+	"first-day"?: number;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info  */
+	"help-text-messages"?: [];
+
+	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info  */
+	"help-text-title"?: string;
+
+	/**  To change the help text icon and style if needed. See help-text component for more info  */
+	"help-text-type"?: string;
+
+	/**  Error messages to show underneath of the input when it has error  */
+	"error-messages"?: [];
+
+	/**  Error title, if there are more than one error message  */
+	"error-title"?: string;
+
+	/**  If the text field has an error, to show error messages and change the style of the input  */
+	"has-error"?: boolean;
+
+	/**  To remove the deselect button and show the asterisk in the label. Not doing the validation, you should set the has-error and error messages yourself  */
+	required?: boolean;
+
+}
+
+export interface TSDatePicker {
+	/**  Can be used for customizing placeholder, days abbreviations, months abbreviations and providing translations for them <br> see the structure in its storybook knobs section. <br>  */
+	translations?: object;
+
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  For setting the date of the date picker you can use this prop/attribute. It will get update after the user changes the date.  */
+	selectedDate?: string;
+
+	/**  This date can be used as a way to customize the month that date picker dropdown will be opened in, <br>  by default it's the current month. You can pass any date in the preferred month.  */
+	pageDate?: string;
+
+	/**  Label of the date picker.  */
+	label?: string;
+
+	/**  Is the date picker disabled?  */
+	disabled?: boolean;
+
+	/**  Is the date picker readonly?  */
+	readonly?: boolean;
+
+	/**  You can pass a function to this prop, which will get js Date object of the days in the calendar view as input, <br>  and expect a boolean to make the day disabled or not.  */
+	isDisabledDate?: function;
+
+	/**  Minimum date which can be selected by the user. Dates before this will be shown as disabled. Supports ISO 8601 format  */
+	min?: string;
+
+	/**  Maximum date which can be selected by the user. Dates after this will be shown as disabled. Supports ISO 8601 format  */
+	max?: string;
+
+	/**  Is the dropdown part opened or not?  */
+	opened?: boolean;
+
+	/**  Disable the typing a new date  */
+	notTypeable?: boolean;
+
+	/**  Which day should be shown as the first day of the week. A number between 0-6 (0 = Sunday, 6 = Saturday)  */
+	firstDay?: number;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info  */
+	helpTextMessages?: [];
+
+	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info  */
+	helpTextTitle?: string;
+
+	/**  To change the help text icon and style if needed. See help-text component for more info  */
+	helpTextType?: string;
+
+	/**  Error messages to show underneath of the input when it has error  */
+	errorMessages?: [];
+
+	/**  Error title, if there are more than one error message  */
+	errorTitle?: string;
+
+	/**  If the text field has an error, to show error messages and change the style of the input  */
+	hasError?: boolean;
+
+	/**  To remove the deselect button and show the asterisk in the label. Not doing the validation, you should set the has-error and error messages yourself  */
+	required?: boolean;
+
+}

--- a/packages/components/dialog/types/dialog.d.ts
+++ b/packages/components/dialog/types/dialog.d.ts
@@ -1,0 +1,47 @@
+export interface TSDialogHTMLAttributes {
+	/**  Dialog can be toggled by add/removing this attribute  */
+	"data-visible"?: boolean;
+
+	/**  Text content of the modal  */
+	text?: string;
+
+	/**  If you need a different icon that default ones, you can use one of Elements icon names  */
+	icon?: string;
+
+	/**  `confirm`, `warning`, `danger`  */
+	type?: string;
+
+	/**  can be used for customizing the buttons text and translations  */
+	translations?: object;
+
+	/**  set the default focus on the button, either `accept` or `cancel`  */
+	focused?: string;
+
+	/**  either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary  */
+	primary?: string;
+
+}
+
+export interface TSDialog {
+	/**  Dialog can be toggled by add/removing this attribute  */
+	visible?: boolean;
+
+	/**  Text content of the modal  */
+	text?: string;
+
+	/**  If you need a different icon that default ones, you can use one of Elements icon names  */
+	icon?: string;
+
+	/**  `confirm`, `warning`, `danger`  */
+	type?: string;
+
+	/**  can be used for customizing the buttons text and translations  */
+	translations?: object;
+
+	/**  set the default focus on the button, either `accept` or `cancel`  */
+	focused?: string;
+
+	/**  either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary  */
+	primary?: string;
+
+}

--- a/packages/components/document-card/types/document-card.d.ts
+++ b/packages/components/document-card/types/document-card.d.ts
@@ -1,8 +1,29 @@
-export declare class TSDocumentCard {
-	dir?: 'rtl' | 'ltr' | 'auto';
+export interface TSDocumentCardHTMLAttributes {
+	dir?: string;
+
 	name?: string;
+
 	description?: string;
+
 	selected?: boolean;
-	'mobile-description'?: string;
+
+	"mobile-description"?: string;
+
 	type?: string;
+
+}
+
+export interface TSDocumentCard {
+	dir?: string;
+
+	name?: string;
+
+	description?: string;
+
+	selected?: boolean;
+
+	mobileDescription?: string;
+
+	type?: string;
+
 }

--- a/packages/components/file-card/types/file-card.d.ts
+++ b/packages/components/file-card/types/file-card.d.ts
@@ -1,8 +1,39 @@
-export declare class TSFileCard {
+export interface TSFileCardHTMLAttributes {
+	/**  type/state of the file card: 'download', 'failed', 'uploading'  */
 	state?: string;
-	'file-object'?: object;
+
+	/**  File data object, {name, size, ...}  */
+	"file-object"?: object;
+
 	rtl?: boolean;
+
+	/**  Show a remove button on the card, which emit an event when it's been clicked  */
 	removable?: boolean;
+
+	/**  Size of the file card: 'full','medium','small'  */
 	size?: string;
-	'error-message'?: string;
+
+	/**  The error message to be shown on the file card when it's in failed state  */
+	"error-message"?: string;
+
+}
+
+export interface TSFileCard {
+	/**  type/state of the file card: 'download', 'failed', 'uploading'  */
+	state?: string;
+
+	/**  File data object, {name, size, ...}  */
+	fileObject?: object;
+
+	rtl?: boolean;
+
+	/**  Show a remove button on the card, which emit an event when it's been clicked  */
+	removable?: boolean;
+
+	/**  Size of the file card: 'full','medium','small'  */
+	size?: string;
+
+	/**  The error message to be shown on the file card when it's in failed state  */
+	errorMessage?: string;
+
 }

--- a/packages/components/file-size/types/file-size.d.ts
+++ b/packages/components/file-size/types/file-size.d.ts
@@ -1,6 +1,29 @@
-export declare class TSFileSize {
+export interface TSFileSizeHTMLAttributes {
+	/**  Size of the file  */
 	size?: number;
-	'decimal-point'?: number;
+
+	/**  How many decimal points should be shown  */
+	"decimal-point"?: number;
+
+	/**  Typography variant  */
 	variant?: string;
+
+	/**  Typography type  */
 	type?: string;
+
+}
+
+export interface TSFileSize {
+	/**  Size of the file  */
+	size?: number;
+
+	/**  How many decimal points should be shown  */
+	decimalPoint?: number;
+
+	/**  Typography variant  */
+	variant?: string;
+
+	/**  Typography type  */
+	type?: string;
+
 }

--- a/packages/components/file-uploader-input/types/file-uploader-input.d.ts
+++ b/packages/components/file-uploader-input/types/file-uploader-input.d.ts
@@ -1,13 +1,65 @@
-export declare class TSFileUploaderInput {
+export interface TSFileUploaderInputHTMLAttributes {
 	rtl?: boolean;
+
+	/**  Disable the input  */
 	disabled?: boolean;
+
+	/**  Allow multiple file select.  */
 	multiple?: boolean;
+
+	/**  Size of the input: 'full'(default), 'medium', 'small'  */
 	size?: string;
-	'accepted-file-extensions'?: string[];
-	'disable-drag-and-drop'?: boolean;
-	'help-text-title'?: string;
-	'help-text-messages'?: string[];
-	'hide-file-type-help-text'?: boolean;
-	'hide-max-file-number-help-text'?: boolean;
-	'max-file-number'?: number;
+
+	/**  List of accepted file extensions  */
+	"accepted-file-extensions"?: [];
+
+	/**  Disable drag and drop functionality  */
+	"disable-drag-and-drop"?: boolean;
+
+	"help-text-title"?: string;
+
+	"help-text-messages"?: [];
+
+	/**  Hide the help text about allowed file types.  */
+	"hide-file-type-help-text"?: boolean;
+
+	/**  Hide the help text about maximum number of files.  */
+	"hide-max-file-number-help-text"?: boolean;
+
+	/**  Maximum limit for number of files to be shown as helper message  */
+	"max-file-number"?: number;
+
+}
+
+export interface TSFileUploaderInput {
+	rtl?: boolean;
+
+	/**  Disable the input  */
+	disabled?: boolean;
+
+	/**  Allow multiple file select.  */
+	multiple?: boolean;
+
+	/**  Size of the input: 'full'(default), 'medium', 'small'  */
+	size?: string;
+
+	/**  List of accepted file extensions  */
+	acceptedFileExtensions?: [];
+
+	/**  Disable drag and drop functionality  */
+	disableDragAndDrop?: boolean;
+
+	helpTextTitle?: string;
+
+	helpTextMessages?: [];
+
+	/**  Hide the help text about allowed file types.  */
+	hideFileTypeHelpText?: boolean;
+
+	/**  Hide the help text about maximum number of files.  */
+	hideMaxFileNumberHelpText?: boolean;
+
+	/**  Maximum limit for number of files to be shown as helper message  */
+	maxFileNumber?: number;
+
 }

--- a/packages/components/header/types/header.d.ts
+++ b/packages/components/header/types/header.d.ts
@@ -1,6 +1,29 @@
-export declare class TSHeader {
-	dir?: 'rtl' | 'ltr' | 'auto';
+export interface TSHeaderHTMLAttributes {
+	/**  Direction of the button `rtl`, `ltr`  */
+	dir?: string;
+
+	/**  Icon shows in the header  */
 	icon?: string;
+
+	/**  Title shows in the header  */
 	title?: string;
+
+	/**  Colors of the header  */
 	color?: string;
+
+}
+
+export interface TSHeader {
+	/**  Direction of the button `rtl`, `ltr`  */
+	dir?: string;
+
+	/**  Icon shows in the header  */
+	icon?: string;
+
+	/**  Title shows in the header  */
+	title?: string;
+
+	/**  Colors of the header  */
+	color?: string;
+
 }

--- a/packages/components/help-text/types/help-text.d.ts
+++ b/packages/components/help-text/types/help-text.d.ts
@@ -1,8 +1,37 @@
-export declare class TSHelpText {
-	messages?: string[];
+export interface TSHelpTextHTMLAttributes {
+	/**  List of message(s)  */
+	messages?: [];
+
+	/**  If there are multiple messages, there should be a title for the help text  */
 	title?: string;
+
 	size?: string;
+
 	rtl?: boolean;
+
+	/**  Apply disabled style for the message  */
 	disabled?: boolean;
+
+	/**  Type of the help text which changes the styling and icon: 'error', 'warning'  */
 	type?: string;
+
+}
+
+export interface TSHelpText {
+	/**  List of message(s)  */
+	messages?: [];
+
+	/**  If there are multiple messages, there should be a title for the help text  */
+	title?: string;
+
+	size?: string;
+
+	rtl?: boolean;
+
+	/**  Apply disabled style for the message  */
+	disabled?: boolean;
+
+	/**  Type of the help text which changes the styling and icon: 'error', 'warning'  */
+	type?: string;
+
 }

--- a/packages/components/icon/types/icon.d.ts
+++ b/packages/components/icon/types/icon.d.ts
@@ -1,10 +1,41 @@
-export { default as icons } from './assets/icons';
-export declare class TSIcon {
+export interface TSIconHTMLAttributes {
+	/**  Icon name, ex: 'arrow-up'  */
 	icon?: string;
+
+	/**  'small' or 'medium' or 'large'  */
 	size?: string;
+
+	/**  Determining icon color, ex: 'error', 'focus'  */
 	type?: string;
+
+	/**  Add circular background for icon  */
 	circular?: boolean;
+
+	/**  90, 180, 270  */
 	rotate?: number;
+
+	/**  'h', 'horizontal', 'v', 'vertical'  */
 	flip?: string;
+
 }
-export { typeColors, types, classNames, sizes } from './utils';
+
+export interface TSIcon {
+	/**  Icon name, ex: 'arrow-up'  */
+	icon?: string;
+
+	/**  'small' or 'medium' or 'large'  */
+	size?: string;
+
+	/**  Determining icon color, ex: 'error', 'focus'  */
+	type?: string;
+
+	/**  Add circular background for icon  */
+	circular?: boolean;
+
+	/**  90, 180, 270  */
+	rotate?: number;
+
+	/**  'h', 'horizontal', 'v', 'vertical'  */
+	flip?: string;
+
+}

--- a/packages/components/input/types/input.d.ts
+++ b/packages/components/input/types/input.d.ts
@@ -1,3 +1,41 @@
-export declare class TSInput {
+export interface TSInputHTMLAttributes {
+	/**  Show error style  */
+	hasError?: boolean;
+
+	/**  Disable state of the input  */
 	disabled?: boolean;
+
+	/**  Readonly state of the input  */
+	readonly?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Icon that appears at the beginning of the input (left in ltr direction)  */
+	"icon-start"?: string;
+
+	/**  Icon that appears at the ending part of the input (right in ltr direction). Readonly and disabled state will show a lock icon instead.  */
+	"icon-end"?: string;
+
+}
+
+export interface TSInput {
+	/**  Show error style  */
+	hasError?: boolean;
+
+	/**  Disable state of the input  */
+	disabled?: boolean;
+
+	/**  Readonly state of the input  */
+	readonly?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Icon that appears at the beginning of the input (left in ltr direction)  */
+	iconStart?: string;
+
+	/**  Icon that appears at the ending part of the input (right in ltr direction). Readonly and disabled state will show a lock icon instead.  */
+	iconEnd?: string;
+
 }

--- a/packages/components/label/types/label.d.ts
+++ b/packages/components/label/types/label.d.ts
@@ -1,3 +1,9 @@
-export declare class TSLabel {
+export interface TSLabelHTMLAttributes {
 	for?: string;
+
+}
+
+export interface TSLabel {
+	for?: string;
+
 }

--- a/packages/components/list-item/types/list-item.d.ts
+++ b/packages/components/list-item/types/list-item.d.ts
@@ -1,12 +1,49 @@
-export declare class TSListItem {
+export interface TSListItemHTMLAttributes {
 	title?: string;
+
 	subtitle?: string;
+
 	disabled?: boolean;
+
 	selectable?: boolean;
+
 	selected?: boolean;
-	dir?: 'rtl' | 'ltr' | 'auto';
+
+	dir?: string;
+
 	icon?: string;
-	'icon-left'?: string;
-	'icon-right'?: string;
-	'no-wrap'?: boolean;
+
+	"icon-left"?: string;
+
+	"icon-right"?: string;
+
+	"icon-selected"?: string;
+
+	"no-wrap"?: boolean;
+
+}
+
+export interface TSListItem {
+	title?: string;
+
+	subtitle?: string;
+
+	disabled?: boolean;
+
+	selectable?: boolean;
+
+	selected?: boolean;
+
+	dir?: string;
+
+	icon?: string;
+
+	iconLeft?: string;
+
+	iconRight?: string;
+
+	iconSelected?: string;
+
+	noWrap?: boolean;
+
 }

--- a/packages/components/modal/types/modal.d.ts
+++ b/packages/components/modal/types/modal.d.ts
@@ -1,14 +1,47 @@
-export { customEventNames, sizes } from './utils';
+export interface TSModalHTMLAttributes {
+	/**  Direction 'rtl' or 'ltr'  */
+	"data-dir"?: string;
 
-export declare class TSModal {
-	'data-dir'?: 'rtl' | 'ltr' | 'auto';
-	'data-size'?: string;
-	'data-title'?: string;
-	'data-visible'?: boolean;
-	'no-close-on-esc-key'?: boolean;
-	'hide-header'?: boolean;
-	'no-padding'?: boolean;
+	/**  Size of the modal. Available variants: 'large', 'medium', 'small'  */
+	"data-size"?: string;
 
-	open(): void;
-	close(): void;
+	/**  Modal header text  */
+	"data-title"?: string;
+
+	/**  Show/hide the modal  */
+	"data-visible"?: boolean;
+
+	/**  Disable the functionality to close the modal on press of escape key  */
+	"no-close-on-esc-key"?: boolean;
+
+	/**  Show/hide the title of the modal  */
+	"hide-header"?: boolean;
+
+	/**  Add/remove standard paddings to the main content  */
+	"no-padding"?: boolean;
+
+}
+
+export interface TSModal {
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Size of the modal. Available variants: 'large', 'medium', 'small'  */
+	size?: string;
+
+	/**  Modal header text  */
+	title?: string;
+
+	/**  Show/hide the modal  */
+	visible?: boolean;
+
+	/**  Disable the functionality to close the modal on press of escape key  */
+	noCloseOnEscKey?: boolean;
+
+	/**  Show/hide the title of the modal  */
+	hideHeader?: boolean;
+
+	/**  Add/remove standard paddings to the main content  */
+	noPadding?: boolean;
+
 }

--- a/packages/components/note/types/note.d.ts
+++ b/packages/components/note/types/note.d.ts
@@ -1,8 +1,29 @@
-export declare class TSNote {
+export interface TSNoteHTMLAttributes {
 	icon?: string;
+
 	type?: string;
-	dir?: 'rtl' | 'ltr' | 'auto';
+
+	dir?: string;
+
 	closeable?: boolean;
+
 	hidden?: boolean;
-	buttons?: any[];
+
+	buttons?: [];
+
+}
+
+export interface TSNote {
+	icon?: string;
+
+	type?: string;
+
+	dir?: string;
+
+	closeable?: boolean;
+
+	hidden?: boolean;
+
+	buttons?: [];
+
 }

--- a/packages/components/overlay/types/overlay.d.ts
+++ b/packages/components/overlay/types/overlay.d.ts
@@ -1,0 +1,23 @@
+export interface TSOverlayHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  The element where the container will be rendered.  */
+	anchor?: object;
+
+	/**  Should the width be based on content (true) or inherited from the anchor (false).  */
+	autoWidth?: boolean;
+
+}
+
+export interface TSOverlay {
+	/**  Direction of the component 'rtl' or 'ltr'.  */
+	dir?: string;
+
+	/**  The element where the container will be rendered.  */
+	anchor?: object;
+
+	/**  Should the width be based on content (true) or inherited from the anchor (false).  */
+	autoWidth?: boolean;
+
+}

--- a/packages/components/pager/types/pager.d.ts
+++ b/packages/components/pager/types/pager.d.ts
@@ -1,6 +1,29 @@
-export declare class TSPager {
-	'total-pages'?: number;
-	'active-page'?: number;
-	'per-page'?: number;
+export interface TSPagerHTMLAttributes {
+	/**  Total number of pages  */
+	"total-pages"?: number;
+
+	/**  Currently active page  */
+	"active-page"?: number;
+
+	/**  Determining maximum number of items in the page, should be either of 10,20,30,40,50  */
+	"per-page"?: number;
+
+	/**  Translated messages for the user locale  */
 	translations?: object;
+
+}
+
+export interface TSPager {
+	/**  Total number of pages  */
+	totalPages?: number;
+
+	/**  Currently active page  */
+	activePage?: number;
+
+	/**  Determining maximum number of items in the page, should be either of 10,20,30,40,50  */
+	perPage?: number;
+
+	/**  Translated messages for the user locale  */
+	translations?: object;
+
 }

--- a/packages/components/popover/types/popover.d.ts
+++ b/packages/components/popover/types/popover.d.ts
@@ -1,0 +1,41 @@
+export interface TSPopoverHTMLAttributes {
+	/**  Is the popover visible or not  */
+	opened?: boolean;
+
+	/**  Placement, relative to the anchor. Could be 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'  */
+	placement?: string;
+
+	/**  Text in the title  */
+	header?: string;
+
+	/**  Anchor element for relative positioning. If you need to position absolutely, leave this empty  */
+	anchor?: string;
+
+	/**  Left offset when popover is positioned absolutely. Use any valid css syntax for the 'left' property  */
+	"position-left"?: string;
+
+	/**  Top offset when popover is positioned absolutely. Use any valid css syntax for the 'top' property  */
+	"position-top"?: string;
+
+}
+
+export interface TSPopover {
+	/**  Is the popover visible or not  */
+	opened?: boolean;
+
+	/**  Placement, relative to the anchor. Could be 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'  */
+	placement?: string;
+
+	/**  Text in the title  */
+	header?: string;
+
+	/**  Anchor element for relative positioning. If you need to position absolutely, leave this empty  */
+	anchor?: string;
+
+	/**  Left offset when popover is positioned absolutely. Use any valid css syntax for the 'left' property  */
+	positionLeft?: string;
+
+	/**  Top offset when popover is positioned absolutely. Use any valid css syntax for the 'top' property  */
+	positionTop?: string;
+
+}

--- a/packages/components/progress-bar/types/progress-bar.d.ts
+++ b/packages/components/progress-bar/types/progress-bar.d.ts
@@ -1,5 +1,17 @@
-export declare class TSProgressBar {
+export interface TSProgressBarHTMLAttributes {
 	total?: number;
+
 	done?: number;
+
 	indeterminate?: boolean;
+
+}
+
+export interface TSProgressBar {
+	total?: number;
+
+	done?: number;
+
+	indeterminate?: boolean;
+
 }

--- a/packages/components/radio-group/types/radio-group.d.ts
+++ b/packages/components/radio-group/types/radio-group.d.ts
@@ -1,7 +1,35 @@
-export declare class TSRadioGroup {
+export interface TSRadioGroupHTMLAttributes {
+	/**  Value of currently chosen ts-radio node  */
 	value?: string;
+
+	/**  Title of radio group  */
 	title?: string;
+
+	/**  Index of checked ts-radio node  */
 	index?: number;
+
+	/**  Is group currently focused for keyboard input  */
 	focused?: boolean;
-	dir?: 'rtl' | 'ltr' | 'auto';
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+}
+
+export interface TSRadioGroup {
+	/**  Value of currently chosen ts-radio node  */
+	value?: string;
+
+	/**  Title of radio group  */
+	title?: string;
+
+	/**  Index of checked ts-radio node  */
+	index?: number;
+
+	/**  Is group currently focused for keyboard input  */
+	focused?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
 }

--- a/packages/components/radio/types/radio.d.ts
+++ b/packages/components/radio/types/radio.d.ts
@@ -1,6 +1,29 @@
-export declare class TSRadio {
+export interface TSRadioHTMLAttributes {
+	/**  Value of the radio  */
 	value?: string;
+
+	/**  Label of the radio  */
 	label?: string;
+
+	/**  Check status  */
 	checked?: boolean;
+
+	/**  Disabled status  */
 	disabled?: boolean;
+
+}
+
+export interface TSRadio {
+	/**  Value of the radio  */
+	value?: string;
+
+	/**  Label of the radio  */
+	label?: string;
+
+	/**  Check status  */
+	checked?: boolean;
+
+	/**  Disabled status  */
+	disabled?: boolean;
+
 }

--- a/packages/components/search/types/search.d.ts
+++ b/packages/components/search/types/search.d.ts
@@ -1,8 +1,41 @@
-export declare class TSSearch {
+export interface TSSearchHTMLAttributes {
+	/**  Shoud the search be auto focused once page loaded  */
 	autofocus?: boolean;
-	dir?: 'rtl' | 'ltr' | 'auto';
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Set the focus on element  */
 	focused?: boolean;
-	'idle-time'?: number;
+
+	/**  timeout in ms for the 'idle' event  */
+	"idle-time"?: number;
+
+	/**  Message when an input is empty  */
 	placeholder?: string;
+
+	/**  The current value  */
 	value?: string;
+
+}
+
+export interface TSSearch {
+	/**  Shoud the search be auto focused once page loaded  */
+	autofocus?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Set the focus on element  */
+	focused?: boolean;
+
+	/**  timeout in ms for the 'idle' event  */
+	idleTime?: number;
+
+	/**  Message when an input is empty  */
+	placeholder?: string;
+
+	/**  The current value  */
+	value?: string;
+
 }

--- a/packages/components/select-menu/types/select-menu.d.ts
+++ b/packages/components/select-menu/types/select-menu.d.ts
@@ -1,12 +1,9 @@
-export interface TSSelectHTMLAttributes {
+export interface TSSelectMenuHTMLAttributes {
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
 	/**  Is component disabled or not.  */
 	disabled?: boolean;
-
-	/**  Is the dropdown part opened or not.  */
-	opened?: boolean;
 
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: [];
@@ -14,29 +11,23 @@ export interface TSSelectHTMLAttributes {
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
 
-	/**  Do not show the apply button and directly emit select-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior.  */
+	/**  Do not show the apply button and directly emit select-menu-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior.  */
 	"no-apply-button"?: boolean;
 
 	/**  List of selected items' ids  */
 	selected?: [];
-
-	/**  Default placeholder when there is no selection.  */
-	placeholder?: string;
 
 	/**  Translated messages for the user locale  */
 	translations?: object;
 
 }
 
-export interface TSSelect {
+export interface TSSelectMenu {
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
 	/**  Is component disabled or not.  */
 	disabled?: boolean;
-
-	/**  Is the dropdown part opened or not.  */
-	opened?: boolean;
 
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: [];
@@ -44,14 +35,11 @@ export interface TSSelect {
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
 
-	/**  Do not show the apply button and directly emit select-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior.  */
+	/**  Do not show the apply button and directly emit select-menu-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior.  */
 	noApplyButton?: boolean;
 
 	/**  List of selected items' ids  */
 	selected?: [];
-
-	/**  Default placeholder when there is no selection.  */
-	placeholder?: string;
 
 	/**  Translated messages for the user locale  */
 	translations?: object;

--- a/packages/components/spinner/types/spinner.d.ts
+++ b/packages/components/spinner/types/spinner.d.ts
@@ -1,6 +1,29 @@
-export declare class TSSpinner {
-	'data-color'?: string;
-	'data-message'?: string;
-	'data-size'?: string;
-	'data-visible'?: boolean;
+export interface TSSpinnerHTMLAttributes {
+	/**  Spinner color, `blue`, `mono`, `white`  */
+	"data-color"?: string;
+
+	/**  Text to show below the spinner  */
+	"data-message"?: string;
+
+	/**  Size of the spinner, `large`, `medium`, `small`  */
+	"data-size"?: string;
+
+	/**  Show/hide the spinner  */
+	"data-visible"?: boolean;
+
+}
+
+export interface TSSpinner {
+	/**  Spinner color, `blue`, `mono`, `white`  */
+	color?: string;
+
+	/**  Text to show below the spinner  */
+	message?: string;
+
+	/**  Size of the spinner, `large`, `medium`, `small`  */
+	size?: string;
+
+	/**  Show/hide the spinner  */
+	visible?: boolean;
+
 }

--- a/packages/components/status/types/status.d.ts
+++ b/packages/components/status/types/status.d.ts
@@ -1,5 +1,17 @@
-export declare class TSStatus {
-	dir?: 'rtl' | 'ltr' | 'auto';
+export interface TSStatusHTMLAttributes {
+	dir?: string;
+
 	status?: string;
+
 	text?: string;
+
+}
+
+export interface TSStatus {
+	dir?: string;
+
+	status?: string;
+
+	text?: string;
+
 }

--- a/packages/components/tab/types/tab.d.ts
+++ b/packages/components/tab/types/tab.d.ts
@@ -1,6 +1,29 @@
-export declare class TSTab {
+export interface TSTabHTMLAttributes {
+	/**  The label text for the header  */
 	label?: string;
+
+	/**  Make the tab selected  */
 	selected?: boolean;
+
+	/**  Icon name from the available icons in the ts-icon component  */
 	icon?: string;
+
+	/**  Number for counter badge next to the label  */
 	counter?: number;
+
+}
+
+export interface TSTab {
+	/**  The label text for the header  */
+	label?: string;
+
+	/**  Make the tab selected  */
+	selected?: boolean;
+
+	/**  Icon name from the available icons in the ts-icon component  */
+	icon?: string;
+
+	/**  Number for counter badge next to the label  */
+	counter?: number;
+
 }

--- a/packages/components/tabs/types/tabs.d.ts
+++ b/packages/components/tabs/types/tabs.d.ts
@@ -1,3 +1,11 @@
-export declare class TSTabs {
-	dir?: 'rtl' | 'ltr' | 'auto';
+export interface TSTabsHTMLAttributes {
+	/**  Direction (rtl/ltr)  */
+	dir?: string;
+
+}
+
+export interface TSTabs {
+	/**  Direction (rtl/ltr)  */
+	dir?: string;
+
 }

--- a/packages/components/text-field/types/text-field.d.ts
+++ b/packages/components/text-field/types/text-field.d.ts
@@ -1,0 +1,113 @@
+export interface TSTextFieldHTMLAttributes {
+	/**  Label of the text field. If you need something more than simple string, use the label slot.  */
+	label?: string;
+
+	/**  Id of the text field   */
+	id?: string;
+
+	/**  Value of the text field  */
+	value?: string;
+
+	/**  Pass type of the input element, if it's not multiline  */
+	type?: string;
+
+	/**  Placeholder of the text field  */
+	placeholder?: string;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info   */
+	"help-text-messages"?: [];
+
+	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info   */
+	"help-text-title"?: string;
+
+	/**  To change the help text icon and style if needed. See help-text component for more info   */
+	"help-text-type"?: string;
+
+	/**  Error messages to show underneath of the input when it has error  */
+	"error-messages"?: [];
+
+	/**  Error title, if there are more than one error message  */
+	"error-title"?: string;
+
+	/**  If the text field has an error, to show error messages and change the style of the input  */
+	"has-error"?: boolean;
+
+	/**  To show the asterisk in the label, not doing validation yet  */
+	required?: boolean;
+
+	/**  Is the text field disabled?  */
+	disabled?: boolean;
+
+	/**  Is the text field readonly?  */
+	readonly?: boolean;
+
+	/**  Will show a textarea instead of an input  */
+	multiline?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Icon that appears at the beginning of the input (left in ltr direction)  */
+	"icon-start"?: string;
+
+	/**  Icon that appears at the end part of the input (end in ltr direction). Readonly and disabled state will show a lock icon instead.  */
+	"icon-end"?: string;
+
+}
+
+export interface TSTextField {
+	/**  Label of the text field. If you need something more than simple string, use the label slot.  */
+	label?: string;
+
+	/**  Id of the text field   */
+	id?: string;
+
+	/**  Value of the text field  */
+	value?: string;
+
+	/**  Pass type of the input element, if it's not multiline  */
+	type?: string;
+
+	/**  Placeholder of the text field  */
+	placeholder?: string;
+
+	/**  Array of messages to pass to help-text component. See help-text component for more info   */
+	helpTextMessages?: [];
+
+	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info   */
+	helpTextTitle?: string;
+
+	/**  To change the help text icon and style if needed. See help-text component for more info   */
+	helpTextType?: string;
+
+	/**  Error messages to show underneath of the input when it has error  */
+	errorMessages?: [];
+
+	/**  Error title, if there are more than one error message  */
+	errorTitle?: string;
+
+	/**  If the text field has an error, to show error messages and change the style of the input  */
+	hasError?: boolean;
+
+	/**  To show the asterisk in the label, not doing validation yet  */
+	required?: boolean;
+
+	/**  Is the text field disabled?  */
+	disabled?: boolean;
+
+	/**  Is the text field readonly?  */
+	readonly?: boolean;
+
+	/**  Will show a textarea instead of an input  */
+	multiline?: boolean;
+
+	/**  Direction 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Icon that appears at the beginning of the input (left in ltr direction)  */
+	iconStart?: string;
+
+	/**  Icon that appears at the end part of the input (end in ltr direction). Readonly and disabled state will show a lock icon instead.  */
+	iconEnd?: string;
+
+}

--- a/packages/components/tooltip/types/tooltip.d.ts
+++ b/packages/components/tooltip/types/tooltip.d.ts
@@ -1,6 +1,29 @@
-export declare class TSTooltip {
+export interface TSTooltipHTMLAttributes {
+	/**  Text that should be shown in the tooltip popover  */
 	tooltip?: string;
+
+	/**  'top', 'bottom', 'right', 'left'  */
 	position?: string;
+
+	/**  Determining width of thee tooltip  */
 	width?: string;
+
+	/**  Disable the tooltip and hide it  */
 	disabled?: boolean;
+
+}
+
+export interface TSTooltip {
+	/**  Text that should be shown in the tooltip popover  */
+	tooltip?: string;
+
+	/**  'top', 'bottom', 'right', 'left'  */
+	position?: string;
+
+	/**  Determining width of thee tooltip  */
+	width?: string;
+
+	/**  Disable the tooltip and hide it  */
+	disabled?: boolean;
+
 }

--- a/packages/components/typography/types/typography.d.ts
+++ b/packages/components/typography/types/typography.d.ts
@@ -1,9 +1,33 @@
-export declare class TSTypography {
+export interface TSTypographyHTMLAttributes {
 	text?: string;
+
 	tooltip?: string;
+
 	variant?: string;
+
 	type?: string;
+
 	inline?: boolean;
-	'no-wrap'?: boolean;
-	'no-tooltip'?: boolean;
+
+	"no-wrap"?: boolean;
+
+	"no-tooltip"?: boolean;
+
+}
+
+export interface TSTypography {
+	text?: string;
+
+	tooltip?: string;
+
+	variant?: string;
+
+	type?: string;
+
+	inline?: boolean;
+
+	noWrap?: boolean;
+
+	noTooltip?: boolean;
+
 }

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const { EOL } = require('os');
+const fs = require('fs').promises;
+const {
+	getComponentNames,
+	constants,
+	compStateLogger,
+	readComponentFile,
+	capitalizeFirstLetter,
+	camelize
+} = require('./helpers');
+
+const generatePropertyLine = (name, type, description) => {
+	let result = '';
+	if (description) {
+		result += `\t/** ${description} */${EOL}`;
+	}
+	if (name.includes('-')) {
+		// if name has dashes we put it in quotes
+		name = `"${name}"`;
+	}
+	// Replace 'Array' with '[]'.
+	// Better to use Array<T> but we don't have information about structure of array items now.
+	if (type.toLowerCase() === 'array') {
+		type = '[]';
+	}
+	result += `\t${name}?: ${type.toLowerCase()};${EOL}${EOL}`;
+	return result;
+};
+
+const getExposedProperties = srcProps =>
+	srcProps.filter(
+		// filter out empty properties and internal properties
+		property => property.Property && !property.Description.includes('INTERNAL')
+	);
+
+const getHtmlAttributeInterfaces = (typesFileContent, className, properties) => {
+	typesFileContent += `export interface TS${className}HTMLAttributes {${EOL}`;
+	properties.forEach(property => {
+		typesFileContent += generatePropertyLine(property.Attribute, property.Type, property.Description);
+	});
+	typesFileContent += `}${EOL}${EOL}`;
+	return typesFileContent;
+};
+
+const getJsPropertiesInterfaces = (typesFileContent, className, properties) => {
+	typesFileContent += `export interface TS${className} {${EOL}`;
+	properties.forEach(property => {
+		typesFileContent += generatePropertyLine(property.Property, property.Type, property.Description);
+	});
+
+	typesFileContent += `}${EOL}`;
+	return typesFileContent;
+};
+/**
+ *  Read description from docs/properties and add it to the src file
+ *  Single time script to update the src file with all available description in README files
+ */
+(async function () {
+	// read the data from the src properties
+	// get the component names
+	const componentNames = getComponentNames();
+	for (const compName of componentNames) {
+		// get the component src properties
+		compStateLogger(compName, 'Reading src/properties.json ...');
+		const componentDir = path.join(process.cwd(), `${constants.componentsPath}/${compName}`);
+		const srcProps = readComponentFile(compName, '/docs/src/properties.json');
+		const properties = getExposedProperties(srcProps);
+
+		const typesFilePath = `${componentDir}/types/${compName}.d.ts`;
+		await fs.mkdir(`${componentDir}/types/`, { recursive: true });
+		const className = camelize(capitalizeFirstLetter(compName));
+		let typesFileContent = '';
+
+		// Generate interface for html attributes
+		typesFileContent = getHtmlAttributeInterfaces(typesFileContent, className, properties);
+		// Generate interface for js properties
+		typesFileContent = getJsPropertiesInterfaces(typesFileContent, className, properties);
+
+		await fs.writeFile(typesFilePath, typesFileContent);
+		compStateLogger(compName, 'Added type definitions.');
+	}
+})();

--- a/scripts/get-readme-template-data.js
+++ b/scripts/get-readme-template-data.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-const path = require('path');
 const tablemark = require('tablemark');
-const componentsPath = `./packages/components`;
-const { compStateLogger } = require('./helpers');
+const { compStateLogger, readComponentFile } = require('./helpers');
 
 module.exports = function (componentName) {
 	const slots = getSlots(componentName);
@@ -45,15 +42,4 @@ function getProperties(componentName) {
 		return propertyData;
 	});
 	return mergedData;
-}
-
-function readComponentFile(componentName, filePth) {
-	const filePath = path.join(process.cwd(), `${componentsPath}/${componentName}${filePth}`);
-	try {
-		const fileContent = fs.readFileSync(filePath, 'utf8');
-		return fileContent.length ? JSON.parse(fileContent) : [];
-	} catch {
-		compStateLogger(componentName, 'No file was found: ' + filePath);
-		return [];
-	}
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const xa = require('xa');
 
+const componentsPath = './packages/components';
+
 const compStateLogger = function (componentName, text) {
 	if (process.env.DEBUG_MODE) {
 		xa.custom(componentName.toUpperCase(), text, { titleColor: 'yellow', backgroundColor: '#212121' });
@@ -16,11 +18,31 @@ const getComponentNames = function () {
 	return componentNames.filter(file => !['.DS_Store', 'root', ''].includes(file));
 };
 
+const capitalizeFirstLetter = function (string) {
+	return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+const camelize = s => s.replace(/-./g, x => x[1].toUpperCase());
+
+function readComponentFile(componentName, filePth) {
+	const filePath = path.join(process.cwd(), `${componentsPath}/${componentName}${filePth}`);
+	try {
+		const fileContent = fs.readFileSync(filePath, 'utf8');
+		return fileContent.length ? JSON.parse(fileContent) : [];
+	} catch {
+		compStateLogger(componentName, 'No file was found: ' + filePath);
+		return [];
+	}
+}
+
 module.exports = {
 	compStateLogger,
 	getComponentNames,
+	capitalizeFirstLetter,
+	camelize,
+	readComponentFile,
 	constants: {
-		componentsPath: './packages/components'
+		componentsPath
 	}
 };
 


### PR DESCRIPTION
Added a script to autogenerate TypeScript d.ts files for each element.
Each component exports two interfaces:
- Interface with HTML attributes (name example: `TSAsideHTMLAttributes`) which could be useful for React jsx type check
- Interface with component properties (`TSAside`) which contains properties for typescript.

Both interfaces are excluding internal attributes and properties.

Added autorun of this script on pre-commit hook and on `preversion` stage.