### PR TITLE
feat(ts-tabs): add id property to the tab button

### DIFF
--- a/packages/components/tab/README.md
+++ b/packages/components/tab/README.md
@@ -30,12 +30,13 @@
 
 ## ➤ Properties
 
-| Property | Attribute | Type    | Default | Description                                                 |
-| -------- | --------- | ------- | ------- | ----------------------------------------------------------- |
-| label    | label     | String  |         | The label text for the header                               |
-| selected | selected  | Boolean | false   | Make the tab selected                                       |
-| icon     | icon      | String  |         | Icon name from the available icons in the ts-icon component |
-| counter  | counter   | Number  |         | Number for counter badge next to the label                  |
+| Property | Attribute | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| label | label | String |  | The label text for the header |
+| selected | selected | Boolean | false | Make the tab selected |
+| icon | icon | String |  | Icon name from the available icons in the ts-icon component |
+| counter | counter | Number |  | Number for counter badge next to the label |
+| id | id | String |  | Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event |
 
 ## ➤ Slots
 

--- a/packages/components/tab/src/tab.js
+++ b/packages/components/tab/src/tab.js
@@ -15,7 +15,9 @@ export class TSTab extends TSElement {
 			/** Icon name from the available icons in the ts-icon component */
 			icon: { type: String, reflect: true },
 			/** Number for counter badge next to the label */
-			counter: { type: Number, reflect: true }
+			counter: { type: Number, reflect: true },
+			/** Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event  */
+			id: { type: String, reflect: true }
 		};
 	}
 

--- a/packages/components/tab/types/tab.d.ts
+++ b/packages/components/tab/types/tab.d.ts
@@ -11,6 +11,9 @@ export interface TSTabHTMLAttributes {
 	/**  Number for counter badge next to the label  */
 	counter?: number;
 
+	/**  Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event   */
+	id?: string;
+
 }
 
 export interface TSTab {
@@ -25,5 +28,8 @@ export interface TSTab {
 
 	/**  Number for counter badge next to the label  */
 	counter?: number;
+
+	/**  Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event   */
+	id?: string;
 
 }

--- a/packages/components/tabs/src/tabs.js
+++ b/packages/components/tabs/src/tabs.js
@@ -65,7 +65,11 @@ export class TSTabs extends TSElement {
 	tabTemplate(tab, index) {
 		/* eslint-disable lit/no-template-bind */
 		return html`
-			<button ?selected="${tab.selected}" @click="${() => this.tabClickHandler(tab, index)}">
+			<button
+				?selected="${tab.selected}"
+				id="${tab.id || `tab-${index}`}"
+				@click="${() => this.tabClickHandler(tab, index)}"
+			>
 				${this.iconTemplate(tab)}
 				<ts-typography text="${tab.label}" variant="semi-bold"></ts-typography>
 				${this.badgeTemplate(tab)}
@@ -83,6 +87,7 @@ export class TSTabs extends TSElement {
 		this.tabs = this.directChildrenTabs.map(tabNode => {
 			return {
 				label: tabNode.getAttribute('label'),
+				id: tabNode.getAttribute('id'),
 				icon: tabNode.getAttribute('icon'),
 				counter: tabNode.getAttribute('counter'),
 				selected: tabNode.getAttribute('selected') !== null

--- a/packages/components/tabs/stories/tabs.stories.js
+++ b/packages/components/tabs/stories/tabs.stories.js
@@ -17,7 +17,7 @@ export const Default = () => {
 	const tabsData = [
 		{ label: 'One', icon: 'ada' },
 		{ label: 'Two', counter: 12 },
-		{ label: 'Three' },
+		{ label: 'Three', id: 'the-third-one' },
 		{ label: 'Four', selected: true },
 		{ label: 'Five', icon: 'ada', counter: 9 },
 		{ label: 'Six' }
@@ -33,6 +33,7 @@ export const Default = () => {
 						icon="${ifDefined(tabData.icon)}"
 						?selected="${tabData.selected}"
 						counter="${ifDefined(tabData.counter)}"
+						id="${ifDefined(tabData.id)}"
 					>
 						<h1>${tabData.label} content</h1>
 					</ts-tab>


### PR DESCRIPTION
To let the developers more easily distinguish the tab (ex. e2e testing selectors), added the id property of ts-tab to the tab header that are generated by the ts-tabs and add the them to the tab button and pass it through as part of the payload of the tab-click event.