### PR TITLE
feat: [PEAA-851] generate react-types for each component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5766,12 +5766,14 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.18.2",
             "lowlight": "~1.11.0",
-            "prismjs": ">=1.25.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": ">=1.25.0",
+              "version": "1.26.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+              "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
               "dev": true
             }
           }
@@ -5794,11 +5796,13 @@
           "requires": {
             "hastscript": "^5.0.0",
             "parse-entities": "^1.1.2",
-            "prismjs": ">=1.25.0"
+            "prismjs": "~1.17.0"
           },
           "dependencies": {
             "prismjs": {
-              "version": ">=1.25.0",
+              "version": "1.26.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+              "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
               "dev": true
             }
           }
@@ -7159,380 +7163,315 @@
     "@tradeshift/elements.action-select": {
       "version": "file:packages/components/action-select",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.overlay": "^0.30.0",
-        "@tradeshift/elements.select-menu": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.overlay": "^0.32.0",
+        "@tradeshift/elements.select-menu": "^0.32.0"
       }
     },
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.cover": "^0.30.0",
-        "@tradeshift/elements.spinner": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.cover": "^0.32.0",
+        "@tradeshift/elements.spinner": "^0.32.0"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.confirmation-prompt": {
       "version": "file:packages/components/confirmation-prompt",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.modal": "^0.30.0",
-        "@tradeshift/elements.text-field": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.modal": "^0.32.0",
+        "@tradeshift/elements.text-field": "^0.32.0"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.date-picker": {
       "version": "file:packages/components/date-picker",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.date-picker-overlay": "^0.30.0",
-        "@tradeshift/elements.overlay": "^0.30.0",
-        "@tradeshift/elements.text-field": "^0.30.0"
-      },
-      "dependencies": {
-        "@tradeshift/elements": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements/0.30.0/23e9ec00274d7d8d226a6e09cec0ad301efb29f93ba82513a17bdc7f3b6133b0",
-          "integrity": "sha512-NbtKIp2QfETGQVEr6h6zq/OM+wkF9sCuHYR0GbzO8ytDhIhu5WilvNqi/8NMy1G49YEnUwZg7SiCZcTCWxULHg==",
-          "requires": {
-            "lit-element": "^2.4.0"
-          }
-        },
-        "@tradeshift/elements.button": {
-          "version": "0.28.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements.button/0.28.0/6c9c0413561d473ad48d71c1323f0a4a4f2d63a700f9862e0258ba0e21f4493d",
-          "integrity": "sha512-24C70oBtk2oPrD3DjZeG1TBTFpiznQapHVfv9WqjF+zF7q9wAb0CcdKPdCj5/f2OM1PlQpn8w6Ytb3ojoyypYA=="
-        },
-        "@tradeshift/elements.overlay": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements.overlay/0.30.0/2251d73114b2eff50b2c18bb91428eb711c0ad719f676d8b9166ed1d846a8723",
-          "integrity": "sha512-UmitgrP7pncCV1opnp+b1kMh5eu/zR/W7Q7+IGV3g8tpOyDL/0C/toP0f4dAYPm9j71Pu/ViPfnuL8mT5BBZ2w==",
-          "requires": {
-            "@tradeshift/elements": "^0.30.0"
-          }
-        },
-        "@tradeshift/elements.text-field": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements.text-field/0.30.0/5ba9a255b751f4fcc82c9dce2fcbf1d743a0b6012f1338afe0430e045a7ff493",
-          "integrity": "sha512-umNZulZRy0VzGtgzESBWAzDCuNFyRfgfQa0rlh7l86DWSYWg9DGWzfS2DTff4GHOVQZlwdk3EoZf1Xvzfyl4zQ==",
-          "requires": {
-            "@tradeshift/elements": "^0.30.0",
-            "@tradeshift/elements.help-text": "^0.30.0",
-            "@tradeshift/elements.input": "^0.30.0"
-          }
-        }
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.date-picker-overlay": "^0.32.0",
+        "@tradeshift/elements.overlay": "^0.32.0",
+        "@tradeshift/elements.text-field": "^0.32.0"
       }
     },
     "@tradeshift/elements.date-picker-overlay": {
       "version": "file:packages/components/date-picker-overlay",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
-      },
-      "dependencies": {
-        "@tradeshift/elements": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements/0.30.0/23e9ec00274d7d8d226a6e09cec0ad301efb29f93ba82513a17bdc7f3b6133b0",
-          "integrity": "sha512-NbtKIp2QfETGQVEr6h6zq/OM+wkF9sCuHYR0GbzO8ytDhIhu5WilvNqi/8NMy1G49YEnUwZg7SiCZcTCWxULHg==",
-          "requires": {
-            "lit-element": "^2.4.0"
-          }
-        }
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.dialog": {
       "version": "file:packages/components/dialog",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.button-group": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.modal": "^0.30.0",
-        "@tradeshift/elements.typography": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.button-group": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.modal": "^0.32.0",
+        "@tradeshift/elements.typography": "^0.32.0"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.card": "^0.30.0",
-        "@tradeshift/elements.file-size": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.progress-bar": "^0.30.0",
-        "@tradeshift/elements.typography": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.card": "^0.32.0",
+        "@tradeshift/elements.file-size": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.progress-bar": "^0.32.0",
+        "@tradeshift/elements.typography": "^0.32.0"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.typography": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.typography": "^0.32.0"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.help-text": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.help-text": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.app-icon": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.app-icon": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.typography": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.typography": "^0.32.0"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.cover": "^0.30.0",
-        "@tradeshift/elements.header": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.cover": "^0.32.0",
+        "@tradeshift/elements.header": "^0.32.0"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.overlay": {
       "version": "file:packages/components/overlay",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.tooltip": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.tooltip": "^0.32.0"
       }
     },
     "@tradeshift/elements.popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.radio": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.radio": "^0.32.0"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0"
       }
     },
     "@tradeshift/elements.select": {
       "version": "file:packages/components/select",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.overlay": "^0.30.0",
-        "@tradeshift/elements.select-menu": "^0.30.0"
-      },
-      "dependencies": {
-        "@tradeshift/elements.overlay": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements.overlay/0.30.0/2251d73114b2eff50b2c18bb91428eb711c0ad719f676d8b9166ed1d846a8723",
-          "integrity": "sha512-UmitgrP7pncCV1opnp+b1kMh5eu/zR/W7Q7+IGV3g8tpOyDL/0C/toP0f4dAYPm9j71Pu/ViPfnuL8mT5BBZ2w==",
-          "requires": {
-            "@tradeshift/elements": "^0.30.0"
-          }
-        },
-        "@tradeshift/elements.select-menu": {
-          "version": "0.30.0",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements.select-menu/0.30.0/0fa89e277bb08101699dc3edff91fffca68d5a1c647acb165d78e96bf9289683",
-          "integrity": "sha512-NWnY9j+LgSG7fF++jOznjkiv480EaNoylIAlXlzlIxcDpL7MKOlIqj0szZLS4B2ufeZsmKp4izpune2TXE0S0A==",
-          "requires": {
-            "@tradeshift/elements": "^0.30.0",
-            "@tradeshift/elements.button": "^0.30.0",
-            "@tradeshift/elements.button-group": "^0.30.0",
-            "@tradeshift/elements.icon": "^0.30.0",
-            "@tradeshift/elements.list-item": "^0.30.0"
-          }
-        }
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.overlay": "^0.32.0",
+        "@tradeshift/elements.select-menu": "^0.32.0"
       }
     },
     "@tradeshift/elements.select-menu": {
       "version": "file:packages/components/select-menu",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.button": "^0.30.0",
-        "@tradeshift/elements.button-group": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.list-item": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.button": "^0.32.0",
+        "@tradeshift/elements.button-group": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.list-item": "^0.32.0"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.icon": "^0.30.0",
-        "@tradeshift/elements.tab": "^0.30.0",
-        "@tradeshift/elements.typography": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.icon": "^0.32.0",
+        "@tradeshift/elements.tab": "^0.32.0",
+        "@tradeshift/elements.typography": "^0.32.0"
       }
     },
     "@tradeshift/elements.text-field": {
       "version": "file:packages/components/text-field",
       "requires": {
-        "@tradeshift/elements": "^0.30.0",
-        "@tradeshift/elements.help-text": "^0.30.0",
-        "@tradeshift/elements.input": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0",
+        "@tradeshift/elements.help-text": "^0.32.0",
+        "@tradeshift/elements.input": "^0.32.0"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.30.0"
+        "@tradeshift/elements": "^0.32.0"
       }
     },
     "@trysound/sax": {
@@ -7766,9 +7705,9 @@
       }
     },
     "@types/react": {
-      "version": "17.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.15.tgz",
-      "integrity": "sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -9928,7 +9867,7 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": ">=4.0.1",
+        "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
@@ -9941,7 +9880,9 @@
           "dev": true
         },
         "set-value": {
-          "version": ">=4.0.1",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",
@@ -17531,8 +17472,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -23821,7 +23761,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": ">=9.0.6",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -23895,7 +23835,9 @@
           }
         },
         "immer": {
-          "version": ">=9.0.6",
+          "version": "9.0.12",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+          "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
           "dev": true
         },
         "ms": {
@@ -24067,12 +24009,14 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.1.1",
         "lowlight": "^1.14.0",
-        "prismjs": ">=1.25.0",
+        "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": ">=1.25.0",
+          "version": "1.26.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+          "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
           "dev": true
         }
       }
@@ -24307,11 +24251,13 @@
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": ">=1.25.0"
+        "prismjs": "~1.25.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": ">=1.25.0",
+          "version": "1.26.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
+          "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
           "dev": true
         }
       }
@@ -24562,7 +24508,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": ">=0.0.3",
+        "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -24571,7 +24517,9 @@
       },
       "dependencies": {
         "trim": {
-          "version": ">=0.0.3",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
+          "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==",
           "dev": true
         }
       }
@@ -27405,11 +27353,21 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": ">=4.0.1"
+        "set-value": "^2.0.1"
       },
       "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
         "set-value": {
-          "version": ">=4.0.1",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-storybook": "build-storybook -s ./static -o .out",
     "build:prod": "cross-env PRODUCTION=true npm run build",
     "check-credentials": "npm whoami && npm whoami --registry=https://npm.pkg.github.com/ && npm whoami --registry=https://registry.npmjs.org/",
-    "check-deps": "lerna exec --stream --no-bail \"depcheck --ignore-dirs=lib,stories\"",
+    "check-deps": "lerna exec --stream --no-bail \"depcheck --ignore-dirs=lib,stories,types\"",
     "clean": "cross-env-shell lerna exec -- rm -f ./lib/*",
     "clean-install": "run-s clean lerna-clean lerna:bootstrap:no-ci",
     "component-gen": "plop component",

--- a/packages/components/action-select/types/react-types.d.ts
+++ b/packages/components/action-select/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSActionSelectHTMLAttributes } from "@tradeshift/elements.action-select";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-action-select": TSActionSelectHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/app-icon/types/react-types.d.ts
+++ b/packages/components/app-icon/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSAppIconHTMLAttributes } from "@tradeshift/elements.app-icon";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-app-icon": TSAppIconHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/aside/types/react-types.d.ts
+++ b/packages/components/aside/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSAsideHTMLAttributes } from "@tradeshift/elements.aside";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-aside": TSAsideHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/basic-table/types/react-types.d.ts
+++ b/packages/components/basic-table/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSBasicTableHTMLAttributes } from "@tradeshift/elements.basic-table";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-basic-table": TSBasicTableHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/board/types/react-types.d.ts
+++ b/packages/components/board/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSBoardHTMLAttributes } from "@tradeshift/elements.board";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-board": TSBoardHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/button-group/types/react-types.d.ts
+++ b/packages/components/button-group/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSButtonGroupHTMLAttributes } from "@tradeshift/elements.button-group";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-button-group": TSButtonGroupHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/button/types/react-types.d.ts
+++ b/packages/components/button/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSButtonHTMLAttributes } from "@tradeshift/elements.button";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-button": TSButtonHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/card/types/react-types.d.ts
+++ b/packages/components/card/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSCardHTMLAttributes } from "@tradeshift/elements.card";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-card": TSCardHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/checkbox/types/react-types.d.ts
+++ b/packages/components/checkbox/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSCheckboxHTMLAttributes } from "@tradeshift/elements.checkbox";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-checkbox": TSCheckboxHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/confirmation-prompt/types/react-types.d.ts
+++ b/packages/components/confirmation-prompt/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSConfirmationPromptHTMLAttributes } from "@tradeshift/elements.confirmation-prompt";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-confirmation-prompt": TSConfirmationPromptHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/cover/types/react-types.d.ts
+++ b/packages/components/cover/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSCoverHTMLAttributes } from "@tradeshift/elements.cover";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-cover": TSCoverHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/date-picker-overlay/types/react-types.d.ts
+++ b/packages/components/date-picker-overlay/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSDatePickerOverlayHTMLAttributes } from "@tradeshift/elements.date-picker-overlay";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-date-picker-overlay": TSDatePickerOverlayHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/date-picker/types/react-types.d.ts
+++ b/packages/components/date-picker/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSDatePickerHTMLAttributes } from "@tradeshift/elements.date-picker";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-date-picker": TSDatePickerHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/dialog/types/react-types.d.ts
+++ b/packages/components/dialog/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSDialogHTMLAttributes } from "@tradeshift/elements.dialog";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-dialog": TSDialogHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/document-card/types/react-types.d.ts
+++ b/packages/components/document-card/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSDocumentCardHTMLAttributes } from "@tradeshift/elements.document-card";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-document-card": TSDocumentCardHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/file-card/types/react-types.d.ts
+++ b/packages/components/file-card/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSFileCardHTMLAttributes } from "@tradeshift/elements.file-card";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-file-card": TSFileCardHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/file-size/types/react-types.d.ts
+++ b/packages/components/file-size/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSFileSizeHTMLAttributes } from "@tradeshift/elements.file-size";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-file-size": TSFileSizeHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/file-uploader-input/types/react-types.d.ts
+++ b/packages/components/file-uploader-input/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSFileUploaderInputHTMLAttributes } from "@tradeshift/elements.file-uploader-input";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-file-uploader-input": TSFileUploaderInputHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/header/types/react-types.d.ts
+++ b/packages/components/header/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSHeaderHTMLAttributes } from "@tradeshift/elements.header";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-header": TSHeaderHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/help-text/types/react-types.d.ts
+++ b/packages/components/help-text/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSHelpTextHTMLAttributes } from "@tradeshift/elements.help-text";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-help-text": TSHelpTextHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/icon/types/react-types.d.ts
+++ b/packages/components/icon/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSIconHTMLAttributes } from "@tradeshift/elements.icon";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-icon": TSIconHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/input/types/react-types.d.ts
+++ b/packages/components/input/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSInputHTMLAttributes } from "@tradeshift/elements.input";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-input": TSInputHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/label/types/react-types.d.ts
+++ b/packages/components/label/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSLabelHTMLAttributes } from "@tradeshift/elements.label";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-label": TSLabelHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/list-item/types/react-types.d.ts
+++ b/packages/components/list-item/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSListItemHTMLAttributes } from "@tradeshift/elements.list-item";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-list-item": TSListItemHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/modal/types/react-types.d.ts
+++ b/packages/components/modal/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSModalHTMLAttributes } from "@tradeshift/elements.modal";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-modal": TSModalHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/note/types/react-types.d.ts
+++ b/packages/components/note/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSNoteHTMLAttributes } from "@tradeshift/elements.note";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-note": TSNoteHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/overlay/types/react-types.d.ts
+++ b/packages/components/overlay/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSOverlayHTMLAttributes } from "@tradeshift/elements.overlay";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-overlay": TSOverlayHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/pager/types/react-types.d.ts
+++ b/packages/components/pager/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSPagerHTMLAttributes } from "@tradeshift/elements.pager";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-pager": TSPagerHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/popover/types/react-types.d.ts
+++ b/packages/components/popover/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSPopoverHTMLAttributes } from "@tradeshift/elements.popover";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-popover": TSPopoverHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/progress-bar/types/react-types.d.ts
+++ b/packages/components/progress-bar/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSProgressBarHTMLAttributes } from "@tradeshift/elements.progress-bar";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-progress-bar": TSProgressBarHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/radio-group/types/react-types.d.ts
+++ b/packages/components/radio-group/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSRadioGroupHTMLAttributes } from "@tradeshift/elements.radio-group";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-radio-group": TSRadioGroupHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/radio/types/react-types.d.ts
+++ b/packages/components/radio/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSRadioHTMLAttributes } from "@tradeshift/elements.radio";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-radio": TSRadioHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/search/types/react-types.d.ts
+++ b/packages/components/search/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSSearchHTMLAttributes } from "@tradeshift/elements.search";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-search": TSSearchHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/select-menu/types/react-types.d.ts
+++ b/packages/components/select-menu/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSSelectMenuHTMLAttributes } from "@tradeshift/elements.select-menu";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-select-menu": TSSelectMenuHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/select/types/react-types.d.ts
+++ b/packages/components/select/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSSelectHTMLAttributes } from "@tradeshift/elements.select";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-select": TSSelectHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/spinner/types/react-types.d.ts
+++ b/packages/components/spinner/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSSpinnerHTMLAttributes } from "@tradeshift/elements.spinner";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-spinner": TSSpinnerHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/status/types/react-types.d.ts
+++ b/packages/components/status/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSStatusHTMLAttributes } from "@tradeshift/elements.status";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-status": TSStatusHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/tab/types/react-types.d.ts
+++ b/packages/components/tab/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSTabHTMLAttributes } from "@tradeshift/elements.tab";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-tab": TSTabHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/tabs/types/react-types.d.ts
+++ b/packages/components/tabs/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSTabsHTMLAttributes } from "@tradeshift/elements.tabs";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-tabs": TSTabsHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/text-field/types/react-types.d.ts
+++ b/packages/components/text-field/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSTextFieldHTMLAttributes } from "@tradeshift/elements.text-field";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-text-field": TSTextFieldHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/tooltip/types/react-types.d.ts
+++ b/packages/components/tooltip/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSTooltipHTMLAttributes } from "@tradeshift/elements.tooltip";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-tooltip": TSTooltipHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/components/typography/types/react-types.d.ts
+++ b/packages/components/typography/types/react-types.d.ts
@@ -1,0 +1,10 @@
+import React from "@types/react";
+import { TSTypographyHTMLAttributes } from "@tradeshift/elements.typography";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-typography": TSTypographyHTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -52,9 +52,23 @@ const getJsPropertiesInterfaces = (typesFileContent, className, properties) => {
 	typesFileContent += `}${EOL}`;
 	return typesFileContent;
 };
+
+const getReactTypesfileContent = (componentName, className) => {
+	return `import React from "@types/react";
+import { TS${className}HTMLAttributes } from "@tradeshift/elements.${componentName}";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ts-${componentName}": TS${className}HTMLAttributes & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}
+`;
+};
+
 /**
- *  Read description from docs/properties and add it to the src file
- *  Single time script to update the src file with all available description in README files
+ *  Read description from src/properties.json and generate d.ts files
  */
 (async function () {
 	// read the data from the src properties
@@ -68,6 +82,7 @@ const getJsPropertiesInterfaces = (typesFileContent, className, properties) => {
 		const properties = getExposedProperties(srcProps);
 
 		const typesFilePath = `${componentDir}/types/${compName}.d.ts`;
+		const reactTypesFilePath = `${componentDir}/types/react-types.d.ts`;
 		await fs.mkdir(`${componentDir}/types/`, { recursive: true });
 		const className = camelize(capitalizeFirstLetter(compName));
 		let typesFileContent = '';
@@ -77,7 +92,10 @@ const getJsPropertiesInterfaces = (typesFileContent, className, properties) => {
 		// Generate interface for js properties
 		typesFileContent = getJsPropertiesInterfaces(typesFileContent, className, properties);
 
+		const reactTypesContent = getReactTypesfileContent(compName, className);
+
 		await fs.writeFile(typesFilePath, typesFileContent);
+		await fs.writeFile(reactTypesFilePath, reactTypesContent);
 		compStateLogger(compName, 'Added type definitions.');
 	}
 })();


### PR DESCRIPTION
Add an additional `d.ts` file for each component with typings for React jsx. To use it in React project simply import this file for each elements component that application using to your d.ts file with application's custom typings.

E.g.:
```ts
import "@tradeshift/elements.aside/types/react-types";
```
It will add typescript validation and IDE suggestions for aside element:
![Intellisense](https://user-images.githubusercontent.com/55530374/148999688-615f962d-bf50-425b-a55d-0b7e8f70cec9.png)

And shows error when you use non-existing attribute:
![Error](https://user-images.githubusercontent.com/55530374/149001442-ded8ea60-23b8-413b-adfa-94089eaf4522.png)

But there is a limitation that it will validate only attributes without dashes. It is a limitation of React types for IntrisicElement that defines all attributes with dashes as `any`.

I tried it in my local react project. I imported it in a separate `declarations.d.ts` file that is created in application, it worked fine.