### PR TITLE
fix: fix the react types import

### DIFF
--- a/packages/components/action-select/types/react-types.d.ts
+++ b/packages/components/action-select/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSActionSelectHTMLAttributes } from "@tradeshift/elements.action-select";
 
 declare global {

--- a/packages/components/app-icon/types/react-types.d.ts
+++ b/packages/components/app-icon/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSAppIconHTMLAttributes } from "@tradeshift/elements.app-icon";
 
 declare global {

--- a/packages/components/aside/types/react-types.d.ts
+++ b/packages/components/aside/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSAsideHTMLAttributes } from "@tradeshift/elements.aside";
 
 declare global {

--- a/packages/components/basic-table/types/react-types.d.ts
+++ b/packages/components/basic-table/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSBasicTableHTMLAttributes } from "@tradeshift/elements.basic-table";
 
 declare global {

--- a/packages/components/board/types/react-types.d.ts
+++ b/packages/components/board/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSBoardHTMLAttributes } from "@tradeshift/elements.board";
 
 declare global {

--- a/packages/components/button-group/types/react-types.d.ts
+++ b/packages/components/button-group/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSButtonGroupHTMLAttributes } from "@tradeshift/elements.button-group";
 
 declare global {

--- a/packages/components/button/types/react-types.d.ts
+++ b/packages/components/button/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSButtonHTMLAttributes } from "@tradeshift/elements.button";
 
 declare global {

--- a/packages/components/card/types/react-types.d.ts
+++ b/packages/components/card/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSCardHTMLAttributes } from "@tradeshift/elements.card";
 
 declare global {

--- a/packages/components/checkbox/types/react-types.d.ts
+++ b/packages/components/checkbox/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSCheckboxHTMLAttributes } from "@tradeshift/elements.checkbox";
 
 declare global {

--- a/packages/components/confirmation-prompt/types/react-types.d.ts
+++ b/packages/components/confirmation-prompt/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSConfirmationPromptHTMLAttributes } from "@tradeshift/elements.confirmation-prompt";
 
 declare global {

--- a/packages/components/cover/types/react-types.d.ts
+++ b/packages/components/cover/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSCoverHTMLAttributes } from "@tradeshift/elements.cover";
 
 declare global {

--- a/packages/components/date-picker-overlay/types/react-types.d.ts
+++ b/packages/components/date-picker-overlay/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSDatePickerOverlayHTMLAttributes } from "@tradeshift/elements.date-picker-overlay";
 
 declare global {

--- a/packages/components/date-picker/types/react-types.d.ts
+++ b/packages/components/date-picker/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSDatePickerHTMLAttributes } from "@tradeshift/elements.date-picker";
 
 declare global {

--- a/packages/components/dialog/types/react-types.d.ts
+++ b/packages/components/dialog/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSDialogHTMLAttributes } from "@tradeshift/elements.dialog";
 
 declare global {

--- a/packages/components/document-card/types/react-types.d.ts
+++ b/packages/components/document-card/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSDocumentCardHTMLAttributes } from "@tradeshift/elements.document-card";
 
 declare global {

--- a/packages/components/file-card/types/react-types.d.ts
+++ b/packages/components/file-card/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSFileCardHTMLAttributes } from "@tradeshift/elements.file-card";
 
 declare global {

--- a/packages/components/file-size/types/react-types.d.ts
+++ b/packages/components/file-size/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSFileSizeHTMLAttributes } from "@tradeshift/elements.file-size";
 
 declare global {

--- a/packages/components/file-uploader-input/types/react-types.d.ts
+++ b/packages/components/file-uploader-input/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSFileUploaderInputHTMLAttributes } from "@tradeshift/elements.file-uploader-input";
 
 declare global {

--- a/packages/components/header/types/react-types.d.ts
+++ b/packages/components/header/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSHeaderHTMLAttributes } from "@tradeshift/elements.header";
 
 declare global {

--- a/packages/components/help-text/types/react-types.d.ts
+++ b/packages/components/help-text/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSHelpTextHTMLAttributes } from "@tradeshift/elements.help-text";
 
 declare global {

--- a/packages/components/icon/types/react-types.d.ts
+++ b/packages/components/icon/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSIconHTMLAttributes } from "@tradeshift/elements.icon";
 
 declare global {

--- a/packages/components/input/types/react-types.d.ts
+++ b/packages/components/input/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSInputHTMLAttributes } from "@tradeshift/elements.input";
 
 declare global {

--- a/packages/components/label/types/react-types.d.ts
+++ b/packages/components/label/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSLabelHTMLAttributes } from "@tradeshift/elements.label";
 
 declare global {

--- a/packages/components/list-item/types/react-types.d.ts
+++ b/packages/components/list-item/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSListItemHTMLAttributes } from "@tradeshift/elements.list-item";
 
 declare global {

--- a/packages/components/modal/types/react-types.d.ts
+++ b/packages/components/modal/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSModalHTMLAttributes } from "@tradeshift/elements.modal";
 
 declare global {

--- a/packages/components/note/types/react-types.d.ts
+++ b/packages/components/note/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSNoteHTMLAttributes } from "@tradeshift/elements.note";
 
 declare global {

--- a/packages/components/overlay/types/react-types.d.ts
+++ b/packages/components/overlay/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSOverlayHTMLAttributes } from "@tradeshift/elements.overlay";
 
 declare global {

--- a/packages/components/pager/types/react-types.d.ts
+++ b/packages/components/pager/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSPagerHTMLAttributes } from "@tradeshift/elements.pager";
 
 declare global {

--- a/packages/components/popover/types/react-types.d.ts
+++ b/packages/components/popover/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSPopoverHTMLAttributes } from "@tradeshift/elements.popover";
 
 declare global {

--- a/packages/components/progress-bar/types/react-types.d.ts
+++ b/packages/components/progress-bar/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSProgressBarHTMLAttributes } from "@tradeshift/elements.progress-bar";
 
 declare global {

--- a/packages/components/radio-group/types/react-types.d.ts
+++ b/packages/components/radio-group/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSRadioGroupHTMLAttributes } from "@tradeshift/elements.radio-group";
 
 declare global {

--- a/packages/components/radio/types/react-types.d.ts
+++ b/packages/components/radio/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSRadioHTMLAttributes } from "@tradeshift/elements.radio";
 
 declare global {

--- a/packages/components/search/types/react-types.d.ts
+++ b/packages/components/search/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSSearchHTMLAttributes } from "@tradeshift/elements.search";
 
 declare global {

--- a/packages/components/select-menu/types/react-types.d.ts
+++ b/packages/components/select-menu/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSSelectMenuHTMLAttributes } from "@tradeshift/elements.select-menu";
 
 declare global {

--- a/packages/components/select/types/react-types.d.ts
+++ b/packages/components/select/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSSelectHTMLAttributes } from "@tradeshift/elements.select";
 
 declare global {

--- a/packages/components/spinner/types/react-types.d.ts
+++ b/packages/components/spinner/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSSpinnerHTMLAttributes } from "@tradeshift/elements.spinner";
 
 declare global {

--- a/packages/components/status/types/react-types.d.ts
+++ b/packages/components/status/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSStatusHTMLAttributes } from "@tradeshift/elements.status";
 
 declare global {

--- a/packages/components/tab/types/react-types.d.ts
+++ b/packages/components/tab/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSTabHTMLAttributes } from "@tradeshift/elements.tab";
 
 declare global {

--- a/packages/components/tabs/types/react-types.d.ts
+++ b/packages/components/tabs/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSTabsHTMLAttributes } from "@tradeshift/elements.tabs";
 
 declare global {

--- a/packages/components/text-field/types/react-types.d.ts
+++ b/packages/components/text-field/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSTextFieldHTMLAttributes } from "@tradeshift/elements.text-field";
 
 declare global {

--- a/packages/components/tooltip/types/react-types.d.ts
+++ b/packages/components/tooltip/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSTooltipHTMLAttributes } from "@tradeshift/elements.tooltip";
 
 declare global {

--- a/packages/components/typography/types/react-types.d.ts
+++ b/packages/components/typography/types/react-types.d.ts
@@ -1,4 +1,4 @@
-import React from "@types/react";
+import React from "react";
 import { TSTypographyHTMLAttributes } from "@tradeshift/elements.typography";
 
 declare global {

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -54,7 +54,7 @@ const getJsPropertiesInterfaces = (typesFileContent, className, properties) => {
 };
 
 const getReactTypesfileContent = (componentName, className) => {
-	return `import React from "@types/react";
+	return `import React from "react";
 import { TS${className}HTMLAttributes } from "@tradeshift/elements.${componentName}";
 
 declare global {


### PR DESCRIPTION
The correct import of React typings by default should be from "react" package.