### PR TITLE
fix(action-select): remove background color

### DIFF
--- a/packages/components/action-select/src/action-select.css
+++ b/packages/components/action-select/src/action-select.css
@@ -1,5 +1,4 @@
 #container {
-	background-color: var(--ts-color-white);
 	display: flex;
 	& ts-icon {
 		cursor: pointer;


### PR DESCRIPTION
the white background overrides any other container color and is not
possible to change
if necessary the background color can be changed from a container

before:
![image](https://user-images.githubusercontent.com/1011245/150142861-8cc68157-2ad2-4dd9-8550-7a3b138668b3.png)

after:
![image](https://user-images.githubusercontent.com/1011245/150142772-9515ef6d-ffe7-4f13-aba5-4aa0ccb1ecdd.png)
