### PR TITLE
[PEAA-842] Action select positioning issue on top-right corner in relative mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ loadPolyfills().then(() => import('./my-app.js'));
 
 - Installation
 
-```hell
+```shell
 $ npm i @webcomponents/webcomponentsjs --save
 ```
 
@@ -194,7 +194,7 @@ $ npx lerna bootstrap     # bootstrap all packages and make sure they work toget
 $ npm start
 ```
 
-- Open [https://localhost:8443/](https://localhost:8443/)
+- Open [http://127.0.0.1:8080/](http://127.0.0.1:8080/), or e.g. http://127.0.0.1:8080/packages/components/{PACKAGE_NAME}/ if you want to test a specific element and that element (PACKAGE_NAME) has got an `index.html` file. If not, feel free to add one. Example: [http://127.0.0.1:8080/packages/components/action-select/](http://127.0.0.1:8080/packages/components/action-select/)
 
 ## ➤ How to contribute
 

--- a/packages/components/action-select/index.html
+++ b/packages/components/action-select/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>Tradeshift Elements: Action-Select</title>
+
+		<!-- Don't shim CSS Custom Properties on IE11 -->
+		<script>
+			if (!window.Promise) {
+				window.ShadyCSS = { nativeCss: true };
+			}
+		</script>
+
+		<!-- Enable ES5 class-less Custom Elements -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+		<!-- Load appropriate polyfills and shims -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+
+		<!-- Set :root CSS Custom Properties -->
+		<link rel="stylesheet" href="/packages/core/src/vars.css" />
+		<!-- Set @font-face for all needed fonts -->
+		<link rel="stylesheet" href="/packages/core/src/fonts.css" />
+		<!-- Set margin/padding to be 0 for <html> -->
+		<link rel="stylesheet" href="/packages/core/src/reset.css" />
+
+		<!-- Load user-styles -->
+		<link rel="stylesheet" href="/index.css" />
+
+		<!-- Load Tradeshift Elements once the polyfills are ready (optional?) -->
+		<script>
+			window.addEventListener('WebComponentsReady', function () {
+				var coreEl = document.createElement('script');
+				coreEl.setAttribute('src', '/packages/core/lib/core.umd.js');
+				document.body.appendChild(coreEl);
+				coreEl.onload = function () {
+					var components = ['header', 'board', 'action-select', 'overlay'];
+					components.forEach(function (component) {
+						var el = document.createElement('script');
+						el.setAttribute('src', '/packages/components/' + component + '/lib/' + component + '.umd.js');
+						document.body.appendChild(el);
+					});
+				};
+			});
+		</script>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	</head>
+
+	<body style="display: flex; justify-content: center">
+		<article>
+			<ts-board data-title="ts-action-select">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 0 10px 20px 0">
+							<ts-action-select
+								items='[{"id":0,"title":"Action Select Item 1"},{"id":1,"title":"Another Action Item 2"},{"id":2,"title":"Some quite pretty very insanely long text item on place number 3 not that it matters but it does"}]'
+							></ts-action-select>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-action-select RTL">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 0 10px 20px 0">
+							<ts-action-select
+								dir="rtl"
+								items='[{"id":0,"title":"Action Select Item 1"},{"id":1,"title":"Another Action Item 2"},{"id":2,"title":"Some quite pretty very insanely long text item on place number 3 not that it matters but it does"}]'
+							></ts-action-select>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+		</article>
+	</body>
+</html>

--- a/packages/components/overlay/src/overlay.js
+++ b/packages/components/overlay/src/overlay.js
@@ -99,19 +99,18 @@ export class TSOverlay extends TSElement {
 	 * @returns {!Object} position on left, right and width of the container
 	 */
 	calculateHorizontalPosition(anchorRect, contentWidth) {
-		const result = { left: 'auto', right: 'auto', width: undefined };
+		const result = { left: 'auto', right: 'auto' };
 		const { width, left, right } = anchorRect;
 		if (this.autoWidth) {
 			// calculate horizontal position
-			const menuWidth = anchorRect.width;
 			const { innerWidth } = window;
 			const fitOnRight = left + contentWidth + HALF_UNIT <= innerWidth;
 			const fitOnLeft = left + width - contentWidth - HALF_UNIT >= 0;
 			if (this.dir === 'rtl') {
 				if (!fitOnRight && !fitOnLeft) {
-					// cannot fit on both sides, align to left border
-					result.right = `${innerWidth - HALF_UNIT - contentWidth}px`;
-				} else if (!fitOnLeft) {
+					// cannot fit on either side, align to left border
+					result.right = `${Math.max(HALF_UNIT, innerWidth - HALF_UNIT - contentWidth)}px`;
+				} else if (!fitOnLeft && fitOnRight) {
 					// cannot fit on left, put on right side
 					result.left = `${left}px`;
 				} else {
@@ -120,11 +119,11 @@ export class TSOverlay extends TSElement {
 				}
 			} else {
 				if (!fitOnRight && !fitOnLeft) {
-					// cannot fit on both sides, align to right border
-					result.left = `${innerWidth - contentWidth - HALF_UNIT - left}px`;
-				} else if (!fitOnRight) {
+					// cannot fit on either side, align to right border
+					result.left = `${Math.max(HALF_UNIT, innerWidth - contentWidth - HALF_UNIT - left)}px`;
+				} else if (fitOnLeft && !fitOnRight) {
 					// cannot fit on right, put on left side
-					result.left = `${left + menuWidth - contentWidth}px`;
+					result.right = `${innerWidth - right}px`;
 				} else {
 					// put on right as default
 					result.left = left + 'px';


### PR DESCRIPTION
As documented in https://tradeshift.atlassian.net/browse/PEAA-842 , the ts-select-action dropout will in some cases miscalculate if it fits in on the right side of its anchor. The basic issue here is that the component tries to calculate that based on, among other factors, the width of the rendered dropout. So it depends on content, and even on wrapping that content. It will re-calculate on window resize, getting valid values.
The changes will reduce this wrong behaviour, but it is probably not bulletproof.
Another issue is that it would sometimes pull dropouts partly off-viewport (opening to the left on narrow enough screens). The changes fix that. The issue:

<img width="318" alt="old-issue-opens-bottom-left" src="https://user-images.githubusercontent.com/95853163/150767892-fc6e7bfd-775f-4c95-bf44-c4055a5d1732.png">
<img width="314" alt="old-issue-opens-top-left" src="https://user-images.githubusercontent.com/95853163/150767900-0e00185b-4491-4ee2-bb1e-8a59cf4354c4.png">

The issue referenced in the task:

![image-20211217-131633](https://user-images.githubusercontent.com/95853163/150768010-46b667ec-32c6-448e-b110-f949bab96c04.png)
![image-20211217-131642](https://user-images.githubusercontent.com/95853163/150768011-9e13dd1a-fde2-4b75-ae98-286f6a45429f.png)
.