### PR TITLE
Add missing types for new components and fix new component template to add them by default

### DIFF
--- a/packages/components/action-select/package.json
+++ b/packages/components/action-select/package.json
@@ -9,8 +9,10 @@
   "main": "lib/action-select.umd.js",
   "module": "lib/action-select.esm.js",
   "browser": "lib/action-select.umd.js",
+  "types": "types/action-select.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/confirmation-prompt/package.json
+++ b/packages/components/confirmation-prompt/package.json
@@ -9,8 +9,10 @@
   "main": "lib/confirmation-prompt.umd.js",
   "module": "lib/confirmation-prompt.esm.js",
   "browser": "lib/confirmation-prompt.umd.js",
+  "types": "types/confirmation-prompt.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/date-picker-overlay/package.json
+++ b/packages/components/date-picker-overlay/package.json
@@ -9,8 +9,10 @@
   "main": "lib/date-picker-overlay.umd.js",
   "module": "lib/date-picker-overlay.esm.js",
   "browser": "lib/date-picker-overlay.umd.js",
+  "types": "types/date-picker-overlay.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -9,8 +9,10 @@
   "main": "lib/date-picker.umd.js",
   "module": "lib/date-picker.esm.js",
   "browser": "lib/date-picker.umd.js",
+  "types": "types/date-picker.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -9,8 +9,10 @@
   "main": "lib/dialog.umd.js",
   "module": "lib/dialog.esm.js",
   "browser": "lib/dialog.umd.js",
+  "types": "types/dialog.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/overlay/package.json
+++ b/packages/components/overlay/package.json
@@ -9,8 +9,10 @@
   "main": "lib/overlay.umd.js",
   "module": "lib/overlay.esm.js",
   "browser": "lib/overlay.umd.js",
+  "types": "types/overlay.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5"

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -9,8 +9,10 @@
   "main": "lib/popover.umd.js",
   "module": "lib/popover.esm.js",
   "browser": "lib/popover.umd.js",
+  "types": "types/popover.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/select-menu/package.json
+++ b/packages/components/select-menu/package.json
@@ -9,8 +9,10 @@
   "main": "lib/select-menu.umd.js",
   "module": "lib/select-menu.esm.js",
   "browser": "lib/select-menu.umd.js",
+  "types": "types/select-menu.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -9,8 +9,10 @@
   "main": "lib/select.umd.js",
   "module": "lib/select.esm.js",
   "browser": "lib/select.umd.js",
+  "types": "types/select.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/packages/components/text-field/package.json
+++ b/packages/components/text-field/package.json
@@ -9,8 +9,10 @@
   "main": "lib/text-field.umd.js",
   "module": "lib/text-field.esm.js",
   "browser": "lib/text-field.umd.js",
+  "types": "types/text-field.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.5",

--- a/plop-templates/components/{{kebabCase name}}/package.json
+++ b/plop-templates/components/{{kebabCase name}}/package.json
@@ -9,8 +9,10 @@
   "main": "lib/{{kebabCase name}}.umd.js",
   "module": "lib/{{kebabCase name}}.esm.js",
   "browser": "lib/{{kebabCase name}}.umd.js",
+  "types": "lib/{{kebabCase name}}.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "types/*"
   ],
   "dependencies": {
     "@tradeshift/elements": "^{{version}}"


### PR DESCRIPTION
Our new components did not contain type definitions references in their package.json and these typings did not published.
This Pr fixes this issue by adding missing types definitions and adjusting new component template to have them by default.