### PR TITLE
chore(release): v0.33.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
 			"message": "chore(release): %s"
 		}
 	},
-	"version": "0.33.5"
+	"version": "0.33.6"
 }

--- a/packages/components/action-select/CHANGELOG.md
+++ b/packages/components/action-select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.action-select

--- a/packages/components/action-select/package.json
+++ b/packages/components/action-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.action-select",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.overlay": "^0.33.5",
-    "@tradeshift/elements.select-menu": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.overlay": "^0.33.6",
+    "@tradeshift/elements.select-menu": "^0.33.6"
   },
   "src": "src/action-select.js"
 }

--- a/packages/components/app-icon/CHANGELOG.md
+++ b/packages/components/app-icon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.app-icon
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.app-icon

--- a/packages/components/app-icon/package.json
+++ b/packages/components/app-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.app-icon",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/app-icon.js"
 }

--- a/packages/components/aside/CHANGELOG.md
+++ b/packages/components/aside/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.aside
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.aside

--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.aside",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.cover": "^0.33.5",
-    "@tradeshift/elements.spinner": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.cover": "^0.33.6",
+    "@tradeshift/elements.spinner": "^0.33.6"
   },
   "src": "src/aside.js"
 }

--- a/packages/components/basic-table/CHANGELOG.md
+++ b/packages/components/basic-table/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.basic-table
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.basic-table

--- a/packages/components/basic-table/package.json
+++ b/packages/components/basic-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.basic-table",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/basic-table.js"
 }

--- a/packages/components/board/CHANGELOG.md
+++ b/packages/components/board/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.board
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.board

--- a/packages/components/board/package.json
+++ b/packages/components/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.board",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/board.js"
 }

--- a/packages/components/button-group/CHANGELOG.md
+++ b/packages/components/button-group/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.button-group
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.button-group

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button-group",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/button-group.js"
 }

--- a/packages/components/button/CHANGELOG.md
+++ b/packages/components/button/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.button
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.button

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/button.js"
 }

--- a/packages/components/card/CHANGELOG.md
+++ b/packages/components/card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.card
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.card

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.card",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/card.js"
 }

--- a/packages/components/checkbox/CHANGELOG.md
+++ b/packages/components/checkbox/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.checkbox
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.checkbox

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.checkbox",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/checkbox.js"
 }

--- a/packages/components/confirmation-prompt/CHANGELOG.md
+++ b/packages/components/confirmation-prompt/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.confirmation-prompt

--- a/packages/components/confirmation-prompt/package.json
+++ b/packages/components/confirmation-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.confirmation-prompt",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.modal": "^0.33.5",
-    "@tradeshift/elements.text-field": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.modal": "^0.33.6",
+    "@tradeshift/elements.text-field": "^0.33.6"
   },
   "src": "src/confirmation-prompt.js"
 }

--- a/packages/components/cover/CHANGELOG.md
+++ b/packages/components/cover/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.cover
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.cover

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.cover",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/cover.js"
 }

--- a/packages/components/date-picker-overlay/CHANGELOG.md
+++ b/packages/components/date-picker-overlay/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.date-picker-overlay

--- a/packages/components/date-picker-overlay/package.json
+++ b/packages/components/date-picker-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker-overlay",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/date-picker/CHANGELOG.md
+++ b/packages/components/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.date-picker

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.date-picker-overlay": "^0.33.5",
-    "@tradeshift/elements.overlay": "^0.33.5",
-    "@tradeshift/elements.text-field": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.date-picker-overlay": "^0.33.6",
+    "@tradeshift/elements.overlay": "^0.33.6",
+    "@tradeshift/elements.text-field": "^0.33.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/dialog/CHANGELOG.md
+++ b/packages/components/dialog/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.dialog

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.dialog",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.button-group": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.modal": "^0.33.5",
-    "@tradeshift/elements.typography": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.button-group": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.modal": "^0.33.6",
+    "@tradeshift/elements.typography": "^0.33.6"
   },
   "src": "src/dialog.js"
 }

--- a/packages/components/document-card/CHANGELOG.md
+++ b/packages/components/document-card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.document-card
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.document-card

--- a/packages/components/document-card/package.json
+++ b/packages/components/document-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.document-card",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/document-card.js"
 }

--- a/packages/components/file-card/CHANGELOG.md
+++ b/packages/components/file-card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.file-card
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.file-card

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-card",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.card": "^0.33.5",
-    "@tradeshift/elements.file-size": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.progress-bar": "^0.33.5",
-    "@tradeshift/elements.typography": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.card": "^0.33.6",
+    "@tradeshift/elements.file-size": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.progress-bar": "^0.33.6",
+    "@tradeshift/elements.typography": "^0.33.6"
   },
   "src": "src/file-card.js"
 }

--- a/packages/components/file-size/CHANGELOG.md
+++ b/packages/components/file-size/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.file-size
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.file-size

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-size",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.typography": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.typography": "^0.33.6"
   },
   "src": "src/file-size.js"
 }

--- a/packages/components/file-uploader-input/CHANGELOG.md
+++ b/packages/components/file-uploader-input/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.file-uploader-input
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.file-uploader-input

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-uploader-input",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.help-text": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.help-text": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/file-uploader-input.js"
 }

--- a/packages/components/header/CHANGELOG.md
+++ b/packages/components/header/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.header
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.header

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.header",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.app-icon": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.app-icon": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/header.js"
 }

--- a/packages/components/help-text/CHANGELOG.md
+++ b/packages/components/help-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.help-text
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.help-text

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.help-text",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/help-text.js"
 }

--- a/packages/components/icon/CHANGELOG.md
+++ b/packages/components/icon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.icon
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.icon

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.icon",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/icon.js"
 }

--- a/packages/components/input/CHANGELOG.md
+++ b/packages/components/input/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.input
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.input

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.input",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/input.js"
 }

--- a/packages/components/label/CHANGELOG.md
+++ b/packages/components/label/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.label
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.label

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.label",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/label.js"
 }

--- a/packages/components/list-item/CHANGELOG.md
+++ b/packages/components/list-item/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.list-item
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.list-item

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.list-item",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.typography": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.typography": "^0.33.6"
   },
   "src": "src/list-item.js"
 }

--- a/packages/components/modal/CHANGELOG.md
+++ b/packages/components/modal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.modal
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.modal

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.modal",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.cover": "^0.33.5",
-    "@tradeshift/elements.header": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.cover": "^0.33.6",
+    "@tradeshift/elements.header": "^0.33.6"
   },
   "src": "src/modal.js"
 }

--- a/packages/components/note/CHANGELOG.md
+++ b/packages/components/note/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.note
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.note

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.note",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/note.js"
 }

--- a/packages/components/overlay/CHANGELOG.md
+++ b/packages/components/overlay/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 ### Bug Fixes

--- a/packages/components/overlay/package.json
+++ b/packages/components/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.overlay",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/overlay.js"
 }

--- a/packages/components/pager/CHANGELOG.md
+++ b/packages/components/pager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.pager
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.pager

--- a/packages/components/pager/package.json
+++ b/packages/components/pager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.pager",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.tooltip": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.tooltip": "^0.33.6"
   },
   "src": "src/pager.js"
 }

--- a/packages/components/popover/CHANGELOG.md
+++ b/packages/components/popover/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.popover

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.popover",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/popover.js"
 }

--- a/packages/components/progress-bar/CHANGELOG.md
+++ b/packages/components/progress-bar/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.progress-bar
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.progress-bar

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.progress-bar",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/progress-bar.js"
 }

--- a/packages/components/radio-group/CHANGELOG.md
+++ b/packages/components/radio-group/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.radio-group
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.radio-group

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio-group",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.radio": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.radio": "^0.33.6"
   },
   "src": "src/radio-group.js"
 }

--- a/packages/components/radio/CHANGELOG.md
+++ b/packages/components/radio/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.radio
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.radio

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/radio.js"
 }

--- a/packages/components/root/CHANGELOG.md
+++ b/packages/components/root/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.root
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.root

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.root",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/root.js"
 }

--- a/packages/components/search/CHANGELOG.md
+++ b/packages/components/search/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.search
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.search

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.search",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6"
   },
   "src": "src/search.js"
 }

--- a/packages/components/select-menu/CHANGELOG.md
+++ b/packages/components/select-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.select-menu

--- a/packages/components/select-menu/package.json
+++ b/packages/components/select-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select-menu",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,11 +15,11 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.button": "^0.33.5",
-    "@tradeshift/elements.button-group": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.list-item": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.button": "^0.33.6",
+    "@tradeshift/elements.button-group": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.list-item": "^0.33.6"
   },
   "src": "src/select-menu.js"
 }

--- a/packages/components/select/CHANGELOG.md
+++ b/packages/components/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.select

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.overlay": "^0.33.5",
-    "@tradeshift/elements.select-menu": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.overlay": "^0.33.6",
+    "@tradeshift/elements.select-menu": "^0.33.6"
   },
   "src": "src/select.js"
 }

--- a/packages/components/spinner/CHANGELOG.md
+++ b/packages/components/spinner/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.spinner
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.spinner

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.spinner",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/spinner.js"
 }

--- a/packages/components/status/CHANGELOG.md
+++ b/packages/components/status/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.status
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.status

--- a/packages/components/status/package.json
+++ b/packages/components/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.status",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/status.js"
 }

--- a/packages/components/tab/CHANGELOG.md
+++ b/packages/components/tab/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.tab
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.tab

--- a/packages/components/tab/package.json
+++ b/packages/components/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tab",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/tab.js"
 }

--- a/packages/components/tabs/CHANGELOG.md
+++ b/packages/components/tabs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.tabs
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.tabs

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tabs",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.icon": "^0.33.5",
-    "@tradeshift/elements.tab": "^0.33.5",
-    "@tradeshift/elements.typography": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.icon": "^0.33.6",
+    "@tradeshift/elements.tab": "^0.33.6",
+    "@tradeshift/elements.typography": "^0.33.6"
   },
   "src": "src/tabs.js"
 }

--- a/packages/components/text-field/CHANGELOG.md
+++ b/packages/components/text-field/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+### Bug Fixes
+
+- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.text-field

--- a/packages/components/text-field/package.json
+++ b/packages/components/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.text-field",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5",
-    "@tradeshift/elements.help-text": "^0.33.5",
-    "@tradeshift/elements.input": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6",
+    "@tradeshift/elements.help-text": "^0.33.6",
+    "@tradeshift/elements.input": "^0.33.6"
   },
   "src": "src/text-field.js"
 }

--- a/packages/components/tooltip/CHANGELOG.md
+++ b/packages/components/tooltip/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.tooltip
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.tooltip

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tooltip",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/tooltip.js"
 }

--- a/packages/components/typography/CHANGELOG.md
+++ b/packages/components/typography/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements.typography
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements.typography

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.typography",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.5"
+    "@tradeshift/elements": "^0.33.6"
   },
   "src": "src/typography.js"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.33.6](https://github.com/Tradeshift/elements/compare/v0.33.5...v0.33.6) (2022-01-24)
+
+**Note:** Version bump only for package @tradeshift/elements
+
 ## [0.33.5](https://github.com/Tradeshift/elements/compare/v0.33.3...v0.33.5) (2022-01-24)
 
 **Note:** Version bump only for package @tradeshift/elements

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",


### PR DESCRIPTION
### Bug Fixes

- add missing types for new components and fix new component template to add them by default ([c491ca8](https://github.com/Tradeshift/elements/commit/c491ca870b5c89fad821757ea0a20a0bf4a50091))