### PR TITLE
fix(storybook): fix missing notes for tabs, tab and progress-bar

### DIFF
--- a/packages/components/progress-bar/stories/progress-bar.stories.js
+++ b/packages/components/progress-bar/stories/progress-bar.stories.js
@@ -18,5 +18,5 @@ export const Default = () => {
 
 Default.story = {
 	name: 'default',
-	parameters: { note: readme }
+	parameters: { notes: readme }
 };

--- a/packages/components/tab/stories/tab.stories.js
+++ b/packages/components/tab/stories/tab.stories.js
@@ -1,0 +1,20 @@
+import { html } from 'lit-html';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import readme from '../README.md';
+
+export default {
+	title: 'ts-tab',
+	decorators: [withKnobs]
+};
+
+export const Default = () => {
+	return html`
+		<h4>You can see the Readme file under notes tab. For the examples, please see the "tabs" component story.</h4>
+	`;
+};
+
+Default.story = {
+	name: 'default',
+	parameters: { notes: readme }
+};

--- a/packages/components/tabs/stories/tabs.stories.js
+++ b/packages/components/tabs/stories/tabs.stories.js
@@ -45,5 +45,5 @@ export const Default = () => {
 
 Default.story = {
 	name: 'default',
-	parameters: { note: readme }
+	parameters: { notes: readme }
 };


### PR DESCRIPTION
- For `progress-bar` and `tabs` there was a typo causing the notes not being shown.
- For `tab` component since it didn't have a story because of its nature that would be useful with tabs component, and being included in tabs story. Added a simple text as story to both show how they can see the example and also get access to readme/notes from the storybook.