### PR TITLE
Update the event comment in search component and fix error in select-like components

### DIFF
--- a/packages/components/action-select/src/action-select.js
+++ b/packages/components/action-select/src/action-select.js
@@ -90,6 +90,7 @@ export class TSActionSelect extends TSElement {
 	removeOverlay() {
 		if (this.closeOverlay) {
 			this.closeOverlay();
+			delete this.closeOverlay;
 		}
 	}
 

--- a/packages/components/date-picker/src/date-picker.js
+++ b/packages/components/date-picker/src/date-picker.js
@@ -151,6 +151,7 @@ export class TSDatePicker extends TSElement {
 	removeOverlay() {
 		if (this.closeOverlay) {
 			this.closeOverlay();
+			delete this.closeOverlay;
 		}
 	}
 

--- a/packages/components/search/README.md
+++ b/packages/components/search/README.md
@@ -46,11 +46,11 @@
 
 ## ➤ Events
 
-| Name   | Description                                                         | Payload            |
-| ------ | ------------------------------------------------------------------- | ------------------ |
-| idle   | Emitted when the user not change input value for a provided timeout | search input value |
-| change | Emitted on every user's change in a search input                    | search input value |
-| search | Emitted when the user press the 'Enter' key                         | search input value |
+| Name | Description | Payload |
+| --- | --- | --- |
+| idle | Emitted when the user not change input value for a provided timeout | search input value |
+| change | Emitted on every user's change in a search input or when user selects an item from the provided `dropdownItems` | search input value |
+| search | Emitted when the user press the 'Enter' key | search input value |
 
 ## ➤ How to use it
 

--- a/packages/components/search/src/search.js
+++ b/packages/components/search/src/search.js
@@ -138,7 +138,7 @@ export class TSSearch extends TSElement {
 					return;
 				}
 				/**
-				 * Emitted on every user's change in a search input
+				 * Emitted on every user's change in a search input or when user selects an item from the provided `dropdownItems`
 				 * @payload search input value
 				 */
 				this.dispatchCustomEvent('change', newVal);

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -146,6 +146,7 @@ export class TSSelect extends TSElement {
 	removeOverlay() {
 		if (this.closeOverlay) {
 			this.closeOverlay();
+			delete this.closeOverlay;
 		}
 	}
 


### PR DESCRIPTION
Added two fixes:
- updated the event comment in search component to reflect a new logic, that it now triggered when user selects an item from dropdown
- delete a closeOverlay reference after it is called because overlay already closed and it will throw an error on next call. It could happen in this case: 
  - open select component (it will keep the reference to the function)
  -  when it got attached to DOM and detached several times (e.g. in aside or modal) it will try to call this function again. But the overlay no longer exists (it got destroyed after first call).
If we remove this reference after a call it should solve the issue.