### PR TITLE
[PEAA-592] Select: add custom filtering + minor bug fixes 

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
 				<li>
 					<a href="/packages/components/search/index.html">Search</a>
 				</li>
+				<li>
+					<a href="/packages/components/select/index.html">Select</a>
+				</li>
 			</ul>
 		</article>
 	</body>

--- a/packages/components/select-menu/README.md
+++ b/packages/components/select-menu/README.md
@@ -40,6 +40,7 @@
 | selected | selected | Array | [] | List of selected items' ids |
 | translations | translations | Object |  | Translated messages for the user locale |
 | loading | loading | Boolean | false | Set component in loading state and render a spinner instead of list of items |
+| caseSensitive | case-sensitive | Boolean | false | Make client side filtering case sensitive which by default is case-insensitive |
 | dirty | dirty | Boolean | false | INTERNAL Does component has uncommited changes or not. |
 | currentSelection | currentSelection | Array | [] | INTERNAL List of currently selected changes that user not commited yet. |
 | filterValue | filterValue | String | '' | INTERNAL Latest input value that was used to filter. |

--- a/packages/components/select-menu/README.md
+++ b/packages/components/select-menu/README.md
@@ -35,6 +35,7 @@
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | items | items | Array |  | List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon |
+| filteredItems | filtered-items | Array |  | List of filtered options based on the select filter input value. You should update the |
 | multiselect | multiselect | Boolean | false | Allow users to select several options or not. |
 | noApplyButton | no-apply-button | Boolean | false | Do not show the apply button and directly emit select-menu-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior. |
 | selected | selected | Array | [] | List of selected items' ids |

--- a/packages/components/select-menu/README.md
+++ b/packages/components/select-menu/README.md
@@ -35,7 +35,7 @@
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | items | items | Array |  | List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon |
-| filteredItems | filtered-items | Array |  | List of filtered options based on the select filter input value. You should update the |
+| filteredItems | filtered-items | Array |  | List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items. |
 | multiselect | multiselect | Boolean | false | Allow users to select several options or not. |
 | noApplyButton | no-apply-button | Boolean | false | Do not show the apply button and directly emit select-menu-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior. |
 | selected | selected | Array | [] | List of selected items' ids |

--- a/packages/components/select-menu/src/select-menu.css
+++ b/packages/components/select-menu/src/select-menu.css
@@ -25,19 +25,19 @@
 	padding: var(--ts-unit) 0;
 }
 
-.apply-button-container {
+.footer-container {
 	background-color: var(--ts-color-white);
 	border-top: var(--ts-border);
 	bottom: 0;
 	position: relative;
+}
 
-	& ts-button-group {
-		padding: var(--ts-unit-half);
-		& ts-button {
-			margin-bottom: 0;
-		}
+.apply-button-container {
+	padding: var(--ts-unit-half);
+	padding-top: 0;
+	& ts-button {
+		margin-bottom: 0;
 	}
-
 	&.show {
 		display: block;
 	}
@@ -59,8 +59,16 @@
 	display: inline-flex;
 	font-size: var(--ts-fontsize-mini);
 	font-weight: var(--ts-fontweight);
-	padding: var(--ts-unit) var(--ts-unit) var(--ts-unit-half) var(--ts-unit);
+	padding: var(--ts-unit);
+
 	& ts-icon {
 		margin-right: var(--ts-unit-half);
+	}
+
+	&.show {
+		display: inline-flex;
+	}
+	&.hide {
+		display: none;
 	}
 }

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -1,4 +1,4 @@
-import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
+import { customElementDefineHelper, html, TSElement, unsafeCSS } from '@tradeshift/elements';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.button-group';
 import '@tradeshift/elements.icon';
@@ -20,6 +20,8 @@ export class TSSelectMenu extends TSElement {
 			disabled: { type: Boolean, reflect: true },
 			/** List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon */
 			items: { type: Array, reflect: true },
+			/** List of filtered options based on the select filter input value. You should update the  */
+			filteredItems: { type: Array, reflect: true, attribute: 'filtered-items' },
 			/** Allow users to select several options or not. */
 			multiselect: { type: Boolean, reflect: true },
 			/** Do not show the apply button and directly emit select-menu-changed when the selection changes.
@@ -140,11 +142,16 @@ export class TSSelectMenu extends TSElement {
 	}
 
 	get displayedItems() {
+		if (this.showSelectedOnly) {
+			return this.items.filter(item => this.currentSelection.indexOf(item.id) > -1);
+		}
+		if (this.filteredItems && this.filterValue) {
+			return this.filteredItems;
+		}
 		const searchString = this.caseSensitive ? this.filterValue : this.filterValue?.toLowerCase();
 		return this.items.filter(item => {
 			const itemTitle = this.caseSensitive ? item.title : item.title.toLowerCase();
-			const isSelected = this.currentSelection.indexOf(item.id) > -1;
-			return itemTitle.indexOf(searchString) > -1 && (this.showSelectedOnly ? isSelected : true);
+			return itemTitle.indexOf(searchString) > -1;
 		});
 	}
 

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -20,7 +20,7 @@ export class TSSelectMenu extends TSElement {
 			disabled: { type: Boolean, reflect: true },
 			/** List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon */
 			items: { type: Array, reflect: true },
-			/** List of filtered options based on the select filter input value. You should update the  */
+			/** List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items. */
 			filteredItems: { type: Array, reflect: true, attribute: 'filtered-items' },
 			/** Allow users to select several options or not. */
 			multiselect: { type: Boolean, reflect: true },
@@ -130,22 +130,22 @@ export class TSSelectMenu extends TSElement {
 	}
 
 	get isVisibleShowSelectedButton() {
-		return this.multiselect && (this.dirty || this.currentSelection.length);
+		return this.multiselect && (this.dirty || this.currentSelection.length > 0);
 	}
 
 	/** @private */
 	get selectButton() {
 		return html`
 			<ts-button-group class="apply-button-container ${this.showApplyButtonContainer ? 'show' : 'hide'}">
-				<ts-button type="primary" @click=${this.applySelection}
-					>${this.translations.select} ${this.currentSelection.length}</ts-button
-				>
+				<ts-button type="primary" @click=${this.applySelection}>
+					${this.translations.select} ${this.currentSelection.length}
+				</ts-button>
 			</ts-button-group>
 		`;
 	}
 
 	get showApplyButtonContainer() {
-		return !this.noApplyButton && this.multiselect && (this.dirty || this.currentSelection.length);
+		return !this.noApplyButton && this.multiselect && (this.dirty || this.currentSelection.length > 0);
 	}
 
 	get displayedItems() {
@@ -163,6 +163,7 @@ export class TSSelectMenu extends TSElement {
 	}
 
 	render() {
+		const displayedItems = this.displayedItems;
 		return html`<div id="listContainer">
 			${this.loading
 				? html`<div class="loading-container">
@@ -171,8 +172,8 @@ export class TSSelectMenu extends TSElement {
 				: html`
 				<ul>
 					${
-						this.displayedItems.length > 0
-							? this.displayedItems.map(
+						displayedItems.length > 0
+							? displayedItems.map(
 									item => html`<ts-list-item
 										class="items-list"
 										selectable

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -117,7 +117,10 @@ export class TSSelectMenu extends TSElement {
 
 	/** @private */
 	get showSelectedButton() {
-		return html`<div class="show-selection" @click="${this.showSelectedClick}">
+		return html`<div
+			class="show-selection ${this.isVisibleShowSelectedButton ? 'show' : 'hide'}"
+			@click="${this.showSelectedClick}"
+		>
 			<ts-icon icon="${this.showSelectedOnly ? 'checkbox' : 'checkbox-on'}" size="large" type="disabled-checked">
 			</ts-icon>
 			${this.showSelectedOnly
@@ -126,10 +129,14 @@ export class TSSelectMenu extends TSElement {
 		</div>`;
 	}
 
+	get isVisibleShowSelectedButton() {
+		return this.multiselect && (this.dirty || this.currentSelection.length);
+	}
+
 	/** @private */
 	get selectButton() {
 		return html`
-			<ts-button-group>
+			<ts-button-group class="apply-button-container ${this.showApplyButtonContainer ? 'show' : 'hide'}">
 				<ts-button type="primary" @click=${this.applySelection}
 					>${this.translations.select} ${this.currentSelection.length}</ts-button
 				>
@@ -138,7 +145,7 @@ export class TSSelectMenu extends TSElement {
 	}
 
 	get showApplyButtonContainer() {
-		return !this.noApplyButton && this.multiselect && this.dirty;
+		return !this.noApplyButton && this.multiselect && (this.dirty || this.currentSelection.length);
 	}
 
 	get displayedItems() {
@@ -184,7 +191,7 @@ export class TSSelectMenu extends TSElement {
 					}
 				</ul>
 			</div>
-			<div class="apply-button-container ${this.showApplyButtonContainer ? 'show' : 'hide'}">
+			<div class="footer-container">
 				${this.showSelectedButton} ${this.selectButton}
 			</div>`}
 		</div>`;

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -149,9 +149,11 @@ export class TSSelectMenu extends TSElement {
 	}
 
 	get displayedItems() {
+		// it should only show selected items, without applying any filter
 		if (this.showSelectedOnly) {
 			return this.items.filter(item => this.currentSelection.indexOf(item.id) > -1);
 		}
+		// it should show the filtered items if they are provided and the filter field is not empty
 		if (this.filteredItems && this.filterValue) {
 			return this.filteredItems;
 		}
@@ -160,6 +162,25 @@ export class TSSelectMenu extends TSElement {
 			const itemTitle = this.caseSensitive ? item.title : item.title.toLowerCase();
 			return itemTitle.indexOf(searchString) > -1;
 		});
+	}
+
+	update(changedProperties) {
+		super.update(changedProperties);
+		if (changedProperties.has('selected')) {
+			this.addSelectedToCurrentSelection();
+		}
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.addSelectedToCurrentSelection();
+	}
+
+	addSelectedToCurrentSelection() {
+		this.currentSelection = [
+			...this.currentSelection,
+			...this.selected.filter(item => this.currentSelection.indexOf(item) === -1)
+		];
 	}
 
 	render() {

--- a/packages/components/select-menu/types/select-menu.d.ts
+++ b/packages/components/select-menu/types/select-menu.d.ts
@@ -8,6 +8,9 @@ export interface TSSelectMenuHTMLAttributes {
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
 
+	/**  List of filtered options based on the select filter input value. You should update the   */
+	"filtered-items"?: any[];
+
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
 
@@ -37,6 +40,9 @@ export interface TSSelectMenu {
 
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
+
+	/**  List of filtered options based on the select filter input value. You should update the   */
+	filteredItems?: any[];
 
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;

--- a/packages/components/select-menu/types/select-menu.d.ts
+++ b/packages/components/select-menu/types/select-menu.d.ts
@@ -8,7 +8,7 @@ export interface TSSelectMenuHTMLAttributes {
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
 
-	/**  List of filtered options based on the select filter input value. You should update the   */
+	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.  */
 	"filtered-items"?: any[];
 
 	/**  Allow users to select several options or not.  */
@@ -41,7 +41,7 @@ export interface TSSelectMenu {
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
 
-	/**  List of filtered options based on the select filter input value. You should update the   */
+	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.  */
 	filteredItems?: any[];
 
 	/**  Allow users to select several options or not.  */

--- a/packages/components/select-menu/types/select-menu.d.ts
+++ b/packages/components/select-menu/types/select-menu.d.ts
@@ -23,6 +23,9 @@ export interface TSSelectMenuHTMLAttributes {
 	/**  Set component in loading state and render a spinner instead of list of items  */
 	loading?: boolean;
 
+	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	"case-sensitive"?: boolean;
+
 }
 
 export interface TSSelectMenu {
@@ -49,5 +52,8 @@ export interface TSSelectMenu {
 
 	/**  Set component in loading state and render a spinner instead of list of items  */
 	loading?: boolean;
+
+	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	caseSensitive?: boolean;
 
 }

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -41,6 +41,7 @@
 | selected | selected | Array | [] | List of selected items' ids |
 | placeholder | placeholder | String |  | Default placeholder when there is no selection. |
 | translations | translations | Object |  | Translated messages for the user locale |
+| caseSensitive | case-sensitive | Boolean | false | Make client side filtering case sensitive which by default is case-insensitive |
 | inputValue | inputValue | String | '' | INTERNAL Current value in input. |
 | filterValue | filterValue | String | '' | INTERNAL Latest input value that was used to filter. |
 

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -42,8 +42,8 @@
 | selected | selected | Array | [] | List of selected items' ids |
 | placeholder | placeholder | String |  | Default placeholder when there is no selection. |
 | translations | translations | Object |  | Translated messages for the user locale |
-| loading | loading | Boolean | false | Show the loading spinner |
-| caseSensitive | case-sensitive | Boolean | false | Make client side filtering case sensitive which by default is case-insensitive |
+| loading | loading | Boolean | false | Show the loading spinner in select dropdown |
+| caseSensitive | case-sensitive | Boolean | false | Make client side filtering case sensitive. This also applies on the filterValue in 'filter-value-change' event |
 | inputValue | inputValue | String | '' | INTERNAL Current value in input. |
 | filterValue | filterValue | String | '' | INTERNAL Latest input value that was used to filter. |
 
@@ -51,7 +51,7 @@
 
 | Name | Description | Payload |
 | --- | --- | --- |
-| filter-value-change | Emitted when filter value of the select changes. You can listen to this to update the |  |
+| filter-value-change | Emitted when filter value of the select changes. You can listen to this for doing custom filtering and providing filteredItems to override the default component filtering. |  |
 | select-changed | Emitted when user applies the selected changes |  |
 
 ## ➤ How to use it

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -36,20 +36,23 @@
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | opened | opened | Boolean | false | Is the dropdown part opened or not. |
 | items | items | Array |  | List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon |
+| filteredItems | filtered-items | Array |  | List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items. |
 | multiselect | multiselect | Boolean | false | Allow users to select several options or not. |
 | noApplyButton | no-apply-button | Boolean | false | Do not show the apply button and directly emit select-changed when the selection changes. <br> Only affects the behaviour when multiselect is enabled, for single selection this is the default behavior. |
 | selected | selected | Array | [] | List of selected items' ids |
 | placeholder | placeholder | String |  | Default placeholder when there is no selection. |
 | translations | translations | Object |  | Translated messages for the user locale |
+| loading | loading | Boolean | false | Show the loading spinner |
 | caseSensitive | case-sensitive | Boolean | false | Make client side filtering case sensitive which by default is case-insensitive |
 | inputValue | inputValue | String | '' | INTERNAL Current value in input. |
 | filterValue | filterValue | String | '' | INTERNAL Latest input value that was used to filter. |
 
 ## ➤ Events
 
-| Name           | Description                                    | Payload |
-| -------------- | ---------------------------------------------- | ------- |
-| select-changed | Emitted when user applies the selected changes |         |
+| Name | Description | Payload |
+| --- | --- | --- |
+| filter-value-change | Emitted when filter value of the select changes. You can listen to this to update the |  |
+| select-changed | Emitted when user applies the selected changes |  |
 
 ## ➤ How to use it
 

--- a/packages/components/select/index.html
+++ b/packages/components/select/index.html
@@ -87,12 +87,7 @@
 									console.log('tsSelect input change event', e.detail.inputValue);
 									tsSelect.loading = true;
 									window.setTimeout(() => {
-										tsSelect.items = [
-											...initialItems,
-											...serverSideFilteredItems.filter(
-												item => !initialItems.some(innerItem => item.id === innerItem.id)
-											)
-										];
+										tsSelect.items = [...initialItems, ...serverSideFilteredItems];
 										tsSelect.loading = false;
 									}, 2000);
 								});
@@ -113,19 +108,12 @@
 								});
 								tsSelectMulti.addEventListener('filter-value-change', e => {
 									console.log('tsSelect input change event', e.detail.filterValue);
-									window.setTimeout(() => {
-										tsSelectMulti.loading = true;
-									}, 2000);
+									tsSelectMulti.loading = true;
 									window.setTimeout(() => {
 										tsSelectMulti.filteredItems = serverSideFilteredItems;
-										tsSelectMulti.items = [
-											...initialItems,
-											...serverSideFilteredItems.filter(
-												item => !initialItems.some(innerItem => item.id === innerItem.id)
-											)
-										];
+										tsSelectMulti.items = [...initialItems, ...serverSideFilteredItems];
 										tsSelectMulti.loading = false;
-									}, 4000);
+									}, 1000);
 								});
 							</script>
 						</div>
@@ -147,12 +135,7 @@
 									tsSelectMultiNoApply.loading = true;
 									window.setTimeout(() => {
 										tsSelectMultiNoApply.filteredItems = serverSideFilteredItems;
-										tsSelectMultiNoApply.items = [
-											...initialItems,
-											...serverSideFilteredItems.filter(
-												item => !initialItems.some(innerItem => item.id === innerItem.id)
-											)
-										];
+										tsSelectMultiNoApply.items = [...initialItems, ...serverSideFilteredItems];
 										tsSelectMultiNoApply.loading = false;
 									}, 1000);
 								});

--- a/packages/components/select/index.html
+++ b/packages/components/select/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Tradeshift Elements: Action-Select</title>
+
+		<!-- Don't shim CSS Custom Properties on IE11 -->
+		<script>
+			if (!window.Promise) {
+				window.ShadyCSS = { nativeCss: true };
+			}
+		</script>
+
+		<!-- Enable ES5 class-less Custom Elements -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+		<!-- Load appropriate polyfills and shims -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+
+		<!-- Set :root CSS Custom Properties -->
+		<link rel="stylesheet" href="/packages/core/src/vars.css" />
+		<!-- Set @font-face for all needed fonts -->
+		<link rel="stylesheet" href="/packages/core/src/fonts.css" />
+		<!-- Set margin/padding to be 0 for <html> -->
+		<link rel="stylesheet" href="/packages/core/src/reset.css" />
+
+		<!-- Load user-styles -->
+		<link rel="stylesheet" href="/index.css" />
+
+		<script type="module" src="/packages/components/select/lib/select.esm.js"></script>
+		<script type="module" src="/packages/components/board/lib/board.esm.js"></script>
+	</head>
+
+	<body style="display: flex; justify-content: center">
+		<script>
+			const initialItems = [
+				{ id: 0, title: 'asd 1' },
+				{ id: 1, title: 'Asd 2' },
+				{ id: 2, title: 'xcv 3' },
+				{ id: 3, title: 'qwe 4' },
+				{ id: 4, title: 'wer 5' },
+				{ id: 5, title: 'QWE 6' },
+				{ id: 6, title: 'yui 7' },
+				{ id: 7, title: 'hjk 8' },
+				{ id: 8, title: 'HJK 9' }
+			];
+			const serverSideFilteredItems = [
+				{ id: 0, title: 'asd 1' },
+				{ id: 1, title: 'Asd 2' },
+				{ id: 10, title: 'ASD 10' },
+				{ id: 11, title: 'aaa 2' },
+				{ id: 12, title: 'aaa 3' },
+				{ id: 13, title: 'aaa 4' },
+				{ id: 14, title: 'aaa 5' },
+				{ id: 15, title: 'aaa 6' },
+				{ id: 16, title: 'aaa 7' },
+				{ id: 17, title: 'aaa 8' },
+				{ id: 18, title: 'aaa 9' }
+			];
+			const translations = {
+				select: 'Select',
+				show_all: 'Show all',
+				no_items: 'Nothing to show here.....',
+				view_selection: 'View selection',
+				loading: 'Loading ...'
+			};
+
+			function initializeSelect(id) {
+				const tsSelect = document.getElementById(id);
+				tsSelect.items = [...initialItems];
+				tsSelect.selected = [];
+				tsSelect.translations = translations;
+				return tsSelect;
+			}
+		</script>
+		<article style="margin-top: 200px">
+			<ts-board data-title="ts-select">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 0 10px 20px 0">
+							<ts-select id="tsSelectLoading" placeholder="loading" loading></ts-select>
+							<ts-select id="tsSelect" placeholder="placeholder"></ts-select>
+							<script>
+								initializeSelect('tsSelectLoading');
+								const tsSelect = initializeSelect('tsSelect');
+								tsSelect.addEventListener('filter-value-change', e => {
+									console.log('tsSelect input change event', e.detail.inputValue);
+									tsSelect.loading = true;
+									window.setTimeout(() => {
+										tsSelect.items = [
+											...initialItems,
+											...serverSideFilteredItems.filter(
+												item => !initialItems.some(innerItem => item.id === innerItem.id)
+											)
+										];
+										tsSelect.loading = false;
+									}, 2000);
+								});
+							</script>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+			<ts-board data-title="ts-select">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 0 10px 20px 0">
+							<ts-select id="tsSelectMulti" placeholder="multiple" multiselect></ts-select>
+							<script>
+								const tsSelectMulti = initializeSelect('tsSelectMulti');
+								tsSelectMulti.addEventListener('select-changed', e => {
+									console.log('tsSelect select change event', e.detail);
+								});
+								tsSelectMulti.addEventListener('filter-value-change', e => {
+									console.log('tsSelect input change event', e.detail.filterValue);
+									window.setTimeout(() => {
+										tsSelectMulti.loading = true;
+									}, 2000);
+									window.setTimeout(() => {
+										tsSelectMulti.filteredItems = serverSideFilteredItems;
+										tsSelectMulti.items = [
+											...initialItems,
+											...serverSideFilteredItems.filter(
+												item => !initialItems.some(innerItem => item.id === innerItem.id)
+											)
+										];
+										tsSelectMulti.loading = false;
+									}, 4000);
+								});
+							</script>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+			<ts-board data-title="ts-select">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 0 10px 20px 0">
+							<ts-select id="tsSelectMultiNoApply" placeholder="multiple" multiselect no-apply-button></ts-select>
+							<script>
+								const tsSelectMultiNoApply = initializeSelect('tsSelectMultiNoApply');
+								tsSelectMultiNoApply.addEventListener('select-changed', e => {
+									console.log('tsSelect select change event', e.detail);
+								});
+								tsSelectMultiNoApply.addEventListener('filter-value-change', e => {
+									console.log('tsSelect input change event', e.detail.filterValue);
+									tsSelectMultiNoApply.loading = true;
+									window.setTimeout(() => {
+										tsSelectMultiNoApply.filteredItems = serverSideFilteredItems;
+										tsSelectMultiNoApply.items = [
+											...initialItems,
+											...serverSideFilteredItems.filter(
+												item => !initialItems.some(innerItem => item.id === innerItem.id)
+											)
+										];
+										tsSelectMultiNoApply.loading = false;
+									}, 1000);
+								});
+							</script>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+		</article>
+	</body>
+</html>

--- a/packages/components/select/index.html
+++ b/packages/components/select/index.html
@@ -68,7 +68,10 @@
 			function initializeSelect(id) {
 				const tsSelect = document.getElementById(id);
 				tsSelect.items = [...initialItems];
-				tsSelect.selected = [];
+				window.setTimeout(() => {
+					// tsSelect.selected = [2];
+					tsSelect.setAttribute('selected', JSON.stringify([2]));
+				}, 3000 * Math.random());
 				tsSelect.translations = translations;
 				return tsSelect;
 			}
@@ -77,7 +80,7 @@
 			<ts-board data-title="ts-select">
 				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
 					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
-						<div style="margin: 0 10px 20px 0">
+						<div style="margin: 10px 20px 0">
 							<ts-select id="tsSelectLoading" placeholder="loading" loading></ts-select>
 							<ts-select id="tsSelect" placeholder="placeholder"></ts-select>
 							<script>
@@ -99,20 +102,36 @@
 			<ts-board data-title="ts-select">
 				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
 					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
-						<div style="margin: 0 10px 20px 0">
+						<div style="margin: 10px 20px 0">
+							Normal multi select
 							<ts-select id="tsSelectMulti" placeholder="multiple" multiselect></ts-select>
 							<script>
 								const tsSelectMulti = initializeSelect('tsSelectMulti');
 								tsSelectMulti.addEventListener('select-changed', e => {
 									console.log('tsSelect select change event', e.detail);
 								});
-								tsSelectMulti.addEventListener('filter-value-change', e => {
+							</script>
+						</div>
+					</div>
+				</div>
+			</ts-board>
+			<ts-board data-title="ts-select">
+				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
+					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
+						<div style="margin: 10px 20px 0">
+							<ts-select id="tsSelectMultiCustom" placeholder="multiple" multiselect></ts-select>
+							<script>
+								const tsSelectMultiCustom = initializeSelect('tsSelectMultiCustom');
+								tsSelectMultiCustom.addEventListener('select-changed', e => {
+									console.log('tsSelect select change event', e.detail);
+								});
+								tsSelectMultiCustom.addEventListener('filter-value-change', e => {
 									console.log('tsSelect input change event', e.detail.filterValue);
-									tsSelectMulti.loading = true;
+									tsSelectMultiCustom.loading = true;
 									window.setTimeout(() => {
-										tsSelectMulti.filteredItems = serverSideFilteredItems;
-										tsSelectMulti.items = [...initialItems, ...serverSideFilteredItems];
-										tsSelectMulti.loading = false;
+										tsSelectMultiCustom.filteredItems = serverSideFilteredItems;
+										tsSelectMultiCustom.items = [...initialItems, ...serverSideFilteredItems];
+										tsSelectMultiCustom.loading = false;
 									}, 1000);
 								});
 							</script>
@@ -123,7 +142,7 @@
 			<ts-board data-title="ts-select">
 				<div slot="header-actions" style="display: flex; align-items: center; justify-content: space-between">
 					<div style="align-items: center; display: flex; margin: 10px 0 10px 10px">
-						<div style="margin: 0 10px 20px 0">
+						<div style="margin: 10px 20px 0">
 							<ts-select id="tsSelectMultiNoApply" placeholder="multiple" multiselect no-apply-button></ts-select>
 							<script>
 								const tsSelectMultiNoApply = initializeSelect('tsSelectMultiNoApply');

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -169,6 +169,9 @@ export class TSSelect extends TSElement {
 
 	/** @private */
 	updateInputValue() {
+		if (this.opened) {
+			return;
+		}
 		if (this.selected.length === 0) {
 			this.inputValue = '';
 			return;

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -20,6 +20,12 @@ export class TSSelect extends TSElement {
 		this._translations = Object.assign({}, translations);
 		this.handleInputDebounced = helpers.debounceEvent(() => {
 			this.filterValue = this.inputValue;
+			/**
+			 * Emitted when filter value of the select changes. You can listen to this to update the
+			 */
+			this.dispatchCustomEvent('filter-value-change', {
+				filterValue: this.caseSensitive ? this.filterValue : this.filterValue.toLowerCase()
+			});
 		}, 300);
 	}
 
@@ -37,6 +43,8 @@ export class TSSelect extends TSElement {
 			opened: { type: Boolean, reflect: true },
 			/** List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon */
 			items: { type: Array, reflect: true },
+			/** List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.   */
+			filteredItems: { type: Array, reflect: true, attribute: 'filtered-items' },
 			/** Allow users to select several options or not. */
 			multiselect: { type: Boolean, reflect: true },
 			/** Do not show the apply button and directly emit select-changed when the selection changes.
@@ -48,6 +56,8 @@ export class TSSelect extends TSElement {
 			placeholder: { type: String, reflect: true },
 			/** Translated messages for the user locale */
 			translations: { type: Object, reflect: true },
+			/** Show the loading spinner  */
+			loading: { type: Boolean, reflect: true },
 			/** Make client side filtering case sensitive which by default is case-insensitive */
 			caseSensitive: { type: Boolean, reflect: true, attribute: 'case-sensitive' },
 			/** INTERNAL Current value in input. */
@@ -235,12 +245,15 @@ export class TSSelect extends TSElement {
 					? html`<ts-overlay id="overlay" @overlay-close=${this.onOverlayCloseListener}>
 							<ts-select-menu
 								.items="${this.items}"
+								.filteredItems="${this.filteredItems}"
 								.dir="${this.dir}"
 								?disabled="${this.disabled}"
 								?multiselect="${this.multiselect}"
 								?no-apply-button="${this.noApplyButton}"
 								.filterValue="${this.filterValue}"
 								.currentSelection="${[...this.selected]}"
+								.translations="${this.translations}"
+								.loading="${this.loading}"
 								.caseSensitive="${this.caseSensitive}"
 								@select-menu-changed=${this.onChangeListener}
 							></ts-select-menu>

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -48,6 +48,8 @@ export class TSSelect extends TSElement {
 			placeholder: { type: String, reflect: true },
 			/** Translated messages for the user locale */
 			translations: { type: Object, reflect: true },
+			/** Make client side filtering case sensitive which by default is case-insensitive */
+			caseSensitive: { type: Boolean, reflect: true, attribute: 'case-sensitive' },
 			/** INTERNAL Current value in input. */
 			inputValue: { type: String, attribute: false },
 			/** INTERNAL Latest input value that was used to filter. */
@@ -239,6 +241,7 @@ export class TSSelect extends TSElement {
 								?no-apply-button="${this.noApplyButton}"
 								.filterValue="${this.filterValue}"
 								.currentSelection="${[...this.selected]}"
+								.caseSensitive="${this.caseSensitive}"
 								@select-menu-changed=${this.onChangeListener}
 							></ts-select-menu>
 					  </ts-overlay>`

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -255,7 +255,7 @@ export class TSSelect extends TSElement {
 								?multiselect="${this.multiselect}"
 								?no-apply-button="${this.noApplyButton}"
 								.filterValue="${this.filterValue}"
-								.currentSelection="${[...this.selected]}"
+								.selected="${[...this.selected]}"
 								.translations="${this.translations}"
 								.loading="${this.loading}"
 								.caseSensitive="${this.caseSensitive}"

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -21,7 +21,8 @@ export class TSSelect extends TSElement {
 		this.handleInputDebounced = helpers.debounceEvent(() => {
 			this.filterValue = this.inputValue;
 			/**
-			 * Emitted when filter value of the select changes. You can listen to this to update the
+			 * Emitted when filter value of the select changes. You can listen to this for doing custom filtering and
+			 * providing filteredItems to override the default component filtering.
 			 */
 			this.dispatchCustomEvent('filter-value-change', {
 				filterValue: this.caseSensitive ? this.filterValue : this.filterValue.toLowerCase()
@@ -56,9 +57,9 @@ export class TSSelect extends TSElement {
 			placeholder: { type: String, reflect: true },
 			/** Translated messages for the user locale */
 			translations: { type: Object, reflect: true },
-			/** Show the loading spinner  */
+			/** Show the loading spinner in select dropdown */
 			loading: { type: Boolean, reflect: true },
-			/** Make client side filtering case sensitive which by default is case-insensitive */
+			/** Make client side filtering case sensitive. This also applies on the filterValue in 'filter-value-change' event */
 			caseSensitive: { type: Boolean, reflect: true, attribute: 'case-sensitive' },
 			/** INTERNAL Current value in input. */
 			inputValue: { type: String, attribute: false },

--- a/packages/components/select/src/utils/translations.js
+++ b/packages/components/select/src/utils/translations.js
@@ -3,5 +3,6 @@ export default {
 	selected: 'Selected',
 	show_all: 'Show all',
 	no_items: 'No items',
-	view_selection: 'View selection'
+	view_selection: 'View selection',
+	loading: 'Loading...'
 };

--- a/packages/components/select/stories/select.happo.js
+++ b/packages/components/select/stories/select.happo.js
@@ -23,7 +23,7 @@ export const TestSingleSelect = () => {
 	return html`
 		<style>
 			.render-block {
-				flex: 0 0 19%;
+				flex: 0 0 16%;
 				height: 400px;
 			}
 		</style>
@@ -72,6 +72,10 @@ export const TestSingleSelect = () => {
 				Opened:
 				<ts-select opened placeholder="Placeholder" .items="${itemsWithIcons}" .selected="${[1]}"></ts-select>
 			</div>
+			<div class="render-block">
+				<p>Simple select in loading state</p>
+				<ts-select opened placeholder="Placeholder" .items="${itemsWithIcons}" loading></ts-select>
+			</div>
 		</div>
 	`;
 };
@@ -80,7 +84,7 @@ export const TestMultipleSelect = () => {
 	return html`
 		<style>
 			.render-block {
-				flex: 0 0 19%;
+				flex: 0 0 16%;
 				height: 600px;
 			}
 		</style>
@@ -127,6 +131,11 @@ export const TestMultipleSelect = () => {
 			<div class="render-block">
 				<p>Multiselect without apply selection button</p>
 				<ts-select multiselect noapply opened placeholder="Placeholder" .items="${items}"></ts-select>
+			</div>
+
+			<div class="render-block">
+				<p>Multiselect select in loading state</p>
+				<ts-select opened placeholder="Placeholder" .items="${itemsWithIcons}" loading></ts-select>
 			</div>
 		</div>
 	`;

--- a/packages/components/select/stories/select.stories.js
+++ b/packages/components/select/stories/select.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
-import { array, boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+import { array, boolean, object, select, text, withKnobs } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import '@tradeshift/elements.select';
 import readme from '../README.md';
@@ -21,22 +22,30 @@ const items = [
 	{ id: 8, title: 'Item 9' }
 ];
 
+function getKnobs() {
+	return {
+		disabled: boolean('disabled', false),
+		opened: boolean('opened', false),
+		placeholder: text('placeholder', 'placeholder'),
+		caseSensitive: boolean('case-sensitive', false),
+		dir: select('dir', { ltr: 'ltr', rtl: 'rtl' }, 'ltr'),
+		loading: boolean('loading', false),
+		translations: object('translations', {
+			select: 'Select',
+			selected: 'Selected',
+			show_all: 'Show all',
+			no_items: 'No items',
+			view_selection: 'View selection',
+			loading: 'Loading...'
+		})
+	};
+}
+
 export const Default = () => {
-	const dir = select(
-		'dir',
-		{
-			ltr: 'ltr',
-			rtl: 'rtl'
-		},
-		'ltr'
-	);
-	const disabled = boolean('disabled', false);
-	const opened = boolean('opened', false);
 	const multiselect = boolean('multiselect', false);
-	const noApplyButton = boolean('no apply button', false);
-	const withIcons = boolean('with icons', false);
-	const placeholder = text('placeholder', 'placeholder');
+	const noApplyButton = boolean('no-apply-button', false);
 	let selected = array('selected', [3]);
+	const withIcons = boolean('with icons', false);
 
 	selected = selected.map(item => Number(item));
 	const selectItems = [...items];
@@ -45,18 +54,24 @@ export const Default = () => {
 			item.icon = 'ada';
 		}
 	}
+	const knobs = getKnobs();
 
 	return html`
 		<div style="max-width: 500px;">
 			<ts-select
-				.dir="${dir}"
-				?disabled="${disabled}"
-				?opened="${opened}"
+				.dir="${knobs.dir}"
+				?disabled="${knobs.disabled}"
+				?opened="${knobs.opened}"
 				?multiselect="${multiselect}"
 				?no-apply-button="${noApplyButton}"
-				.placeholder="${placeholder}"
+				.placeholder="${knobs.placeholder}"
 				.selected="${selected}"
 				.items="${selectItems}"
+				?case-sensitive="${knobs.caseSensitive}"
+				?loading="${knobs.loading}"
+				.translations="${knobs.translations}"
+				@filter-value-change="${action('"filter-value-change" event being called!')}"
+				@select-changed="${action('"select-changed" event being called!')}"
 			></ts-select>
 		</div>
 	`;
@@ -64,6 +79,130 @@ export const Default = () => {
 
 Default.story = {
 	name: 'default',
+	parameters: {
+		notes: readme
+	}
+};
+
+export const CustomFiltering = () => {
+	const multiselect = boolean('multiselect', false);
+	const noApplyButton = boolean('no-apply-button', false);
+	const knobs = getKnobs();
+
+	return html`
+		<style>
+			li {
+				margin-bottom: 10px;
+			}
+		</style>
+		<div style="font-family: 'Open Sans';">
+			<div style="max-width: 500px;">
+				<ts-select
+					id="tsSelect"
+					?disabled="${knobs.disabled}"
+					?opened="${knobs.opened}"
+					?multiselect="${multiselect}"
+					?no-apply-button="${noApplyButton}"
+					.placeholder="${knobs.placeholder}"
+					.items="${items}"
+					?case-sensitive="${knobs.caseSensitive}"
+				></ts-select>
+			</div>
+			<script>
+				const tsSelectEl = document.getElementById('tsSelect');
+				tsSelectEl.addEventListener('filter-value-change', function(event) {
+					const filterValue = event.detail.filterValue;
+					tsSelectEl.loading = true;
+					window.setTimeout(function() {
+						const filteredItems = [
+							{ id: 8, title: 'Item 9' },
+							{ id: 666, title: filterValue + ' 666' },
+							{ id: 777, title: filterValue + ' 777' },
+							{ id: 888, title: filterValue + ' 888' },
+							{ id: 999, title: filterValue + ' 999' },
+						];
+						tsSelectEl.items = [
+							...tsSelectEl.items,
+							...filteredItems.filter(item => !tsSelectEl.items.some(innerItem => innerItem.id === item.id ))
+						];
+							tsSelectEl.filteredItems = filteredItems;
+							tsSelectEl.loading = false;
+					}, 1000);
+				});
+			</script>
+			<br/>
+			<hr/>
+			<h4>How to implement?*</h4>
+			<p style="line-height: 20px;">
+				You can have custom filtering with the select component and override the default select component filtering.
+				<ol>
+					<li>Listen to the "filter-value-change" and get the user inputted value in select search input</li>
+					<li>Based on the filter value, you can do your own custom filtering including serverside search</li>
+					<li>If it is going to be asynchronous, you should set the "loading" property/attribute during that process</li>
+					<li>You should set the result list of the filtered items to "filteredItems" property/"filtered-items" attribute and remove the loading prop</li>
+					<li>Remember the items list needs to include the filter items as well, so if you search for items from server side remember to add them to items list.</li>
+				</ol>
+			<i>* You can see the example code in "story" tab.</i>
+			</p>
+		</div>
+	`;
+};
+
+CustomFiltering.story = {
+	name: 'Custom Filtering',
+	parameters: {
+		notes: readme
+	}
+};
+
+export const noApplyButton = () => {
+	const knobs = getKnobs();
+
+	return html`
+		<style>
+			li {
+				margin-bottom: 10px;
+			}
+		</style>
+		<div style="font-family: 'Open Sans';">
+			<div style="max-width: 500px;">
+				<ts-select
+					id="tsSelect"
+					?disabled="${knobs.disabled}"
+					?opened="${knobs.opened}"
+					.placeholder="${knobs.placeholder}"
+					.items="${items}"
+					?case-sensitive="${knobs.caseSensitive}"
+					?loading="${knobs.loading}"
+					multiselect
+					no-apply-button
+				></ts-select>
+			</div>
+
+			<script>
+				const tsSelectEl = document.getElementById('tsSelect');
+				tsSelectEl.addEventListener('select-changed', function(event) {
+					console.log('select-changed called', event.detail.selected);
+				});
+			</script>
+			<br/>
+			<hr/>
+			<h4>How does it work?</h4>
+			<p style="line-height: 20px;">
+				You can make the select component in the multiselect mode to not have the apply selection button.
+			this means:
+				<ul>
+					<li>the item that the user selects or deselects would be applied instantly to the selected items</li>
+					<li>'select-changed' will be emitted right after the user select each item instead of only being emitted once the user applied the current selection</li>
+				</ul>
+			<i>* You can see the example code in "story" tab.</i>
+			</p>
+		</div>
+	`;
+};
+
+noApplyButton.story = {
+	name: 'Multiselect Without Apply Button',
 	parameters: {
 		notes: readme
 	}

--- a/packages/components/select/types/select.d.ts
+++ b/packages/components/select/types/select.d.ts
@@ -26,6 +26,9 @@ export interface TSSelectHTMLAttributes {
 	/**  Translated messages for the user locale  */
 	translations?: object;
 
+	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	"case-sensitive"?: boolean;
+
 }
 
 export interface TSSelect {
@@ -55,5 +58,8 @@ export interface TSSelect {
 
 	/**  Translated messages for the user locale  */
 	translations?: object;
+
+	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	caseSensitive?: boolean;
 
 }

--- a/packages/components/select/types/select.d.ts
+++ b/packages/components/select/types/select.d.ts
@@ -29,10 +29,10 @@ export interface TSSelectHTMLAttributes {
 	/**  Translated messages for the user locale  */
 	translations?: object;
 
-	/**  Show the loading spinner   */
+	/**  Show the loading spinner in select dropdown  */
 	loading?: boolean;
 
-	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	/**  Make client side filtering case sensitive. This also applies on the filterValue in 'filter-value-change' event  */
 	"case-sensitive"?: boolean;
 
 }
@@ -68,10 +68,10 @@ export interface TSSelect {
 	/**  Translated messages for the user locale  */
 	translations?: object;
 
-	/**  Show the loading spinner   */
+	/**  Show the loading spinner in select dropdown  */
 	loading?: boolean;
 
-	/**  Make client side filtering case sensitive which by default is case-insensitive  */
+	/**  Make client side filtering case sensitive. This also applies on the filterValue in 'filter-value-change' event  */
 	caseSensitive?: boolean;
 
 }

--- a/packages/components/select/types/select.d.ts
+++ b/packages/components/select/types/select.d.ts
@@ -11,6 +11,9 @@ export interface TSSelectHTMLAttributes {
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
 
+	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.    */
+	"filtered-items"?: any[];
+
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
 
@@ -25,6 +28,9 @@ export interface TSSelectHTMLAttributes {
 
 	/**  Translated messages for the user locale  */
 	translations?: object;
+
+	/**  Show the loading spinner   */
+	loading?: boolean;
 
 	/**  Make client side filtering case sensitive which by default is case-insensitive  */
 	"case-sensitive"?: boolean;
@@ -44,6 +50,9 @@ export interface TSSelect {
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
 	items?: any[];
 
+	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.    */
+	filteredItems?: any[];
+
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
 
@@ -58,6 +67,9 @@ export interface TSSelect {
 
 	/**  Translated messages for the user locale  */
 	translations?: object;
+
+	/**  Show the loading spinner   */
+	loading?: boolean;
 
 	/**  Make client side filtering case sensitive which by default is case-insensitive  */
 	caseSensitive?: boolean;


### PR DESCRIPTION
- [feat(select): add case-sensitive filtering to select component](https://github.com/Tradeshift/elements/pull/420/commits/ee8182f4ca559e2815d6ee4e54f638e20b528dec) 
   `caseSensitive` property or `case-sensitive` can be passed to the select and select-menu components to make the filtering/search case-sensitive.
- [feat(select): add custom filtering to select component](https://github.com/Tradeshift/elements/pull/420/commits/690abf8ff1cd4164dcfead0d33e1d49c0f934cab) 
    Now it's possible to do custom filtering beside the basic filter that is done by default for item.title text. Now developers can listen to `filter-value-change` event, to get the user inputed value for search/filter and pass `filteredItems` to override the default internal filter/search through the already provided items. To make it possible to do the filtering asynchronously, added loading state to the select component.

    Note: Items that are provided for `filteredItems`, should be also included in `items`, which means developers should make sure they add them to items list if they are not already there and not remove other items for multi select, since they can be already in current selection state.
    
    
 - [fix(select): show the View selection button in multi select with no apply](https://github.com/Tradeshift/elements/pull/420/commits/c70c4f606e9b0548235e6ab539ed124acaa6fce3) 
    The `View selection` button was getting hidden by setting the noApplyButton property, which was not the correct behaviour. The `View selection` button should also be visible when there is already some selected items for the select, even if the user did not change the selection.
    
- [fix(select): do not set input value for multi select and no apply](https://github.com/Tradeshift/elements/pull/420/commits/b5abd2129c38e464a719f08b6b7bdaa8599635e6) 
    In the no apply button mode, since we change the selection without changing the `opened` state of the component, it would set the input value, which was overriding the entered filter value and causing bad user experience. Since there's no scenario that we want to set the input value while select-menu is open, just ignoring the update input value request.
    
### new added commits:

- [fix(select): peaa-941 current selection clears on search input](https://github.com/Tradeshift/elements/pull/420/commits/15b80caaa96ace990e9616a317492c5d74397258) 
   After user started typing in the search input of the select component, the currentSelection was overwritten in select-menu.js by the selected items of the select.js.
Now it updates the current selection at the beginning and when it updates, so the currentSelection would remain only for the staging state of multiselect. 

- [chore(select): add more stories and test](https://github.com/Tradeshift/elements/pull/420/commits/095095d21767713f6ffed39fd3c1c34d55b98efc) 
    - Added stories for custom filtering and no apply button mode: added stories with more information about the component behaviour and what can be done with it.
   - Fixed missing description for events and props
    