### PR TITLE
fix(tag): fixes padding issue in locked and deletable items; also cle…

### DIFF
--- a/packages/components/tag/index.html
+++ b/packages/components/tag/index.html
@@ -101,7 +101,10 @@
 					</div>
 					<ts-tag tabindex="0" clickable labels='["type"]' values='["blue"]' type="blue"></ts-tag>
 					<ts-tag tabindex="0" clickable labels='["type"]' values='["blue-lite"]' type="blue-lite"></ts-tag>
+					<ts-tag locked tabindex="0" clickable labels='["type"]' values='["blue"]' type="blue"></ts-tag>
+					<ts-tag locked tabindex="0" clickable labels='["type"]' values='["blue-lite"]' type="blue-lite"></ts-tag>
 					<ts-tag
+						locked
 						tabindex="0"
 						clickable
 						labels='["type"]'

--- a/packages/components/tag/index.html
+++ b/packages/components/tag/index.html
@@ -60,7 +60,7 @@
 				}, 1000);
 			});
 
-			window.addEventListener('click-tag', e => console.log('klik tag', e.target.id));
+			window.addEventListener('click-tag', e => console.log('click tag', e.target.id));
 
 			// example of catching keyboard enter events on focused ts-tags:
 			window.addEventListener('keyup', e => {
@@ -87,7 +87,7 @@
 						></ts-tag
 					></span>
 					<ts-tag tabindex="0" clickable labels='["key only"]' locked></ts-tag>
-					<ts-tag tabindex="0" clickable values='["Value only"]' deletable locked></ts-tag>
+					<ts-tag dir="rtl" tabindex="0" values='["Value only"]' deletable locked></ts-tag>
 					<ts-tag tabindex="0" clickable labels='["key 1", "key 2"]' type="danger"></ts-tag>
 					<ts-tag tabindex="0" clickable labels='["type"]' values='["warning"]' type="warning"></ts-tag>
 					<div>
@@ -108,7 +108,7 @@
 						values='["unknown type", "defaults to this"]'
 						type="unknown-type"
 					></ts-tag>
-					<a href="https://dr.dk">
+					<a href="#">
 						<ts-tag tabindex="0" clickable labels='["In a", "link"]' values='["value"]'></ts-tag>
 					</a>
 					<ts-tag tabindex="0" clickable labels='["clickable"]' values='["true"]' type="danger" clickable></ts-tag>

--- a/packages/components/tag/src/tag.css
+++ b/packages/components/tag/src/tag.css
@@ -49,7 +49,8 @@
 :host([type='blue-lite']:focus-within) {
 	outline-color: var(--ts-color-blue-light);
 }
-:host(:not([type]):focus-within) {
+:host(:not([type]):focus-within),
+:host([locked]:focus-within) {
 	outline-color: var(--ts-color-gray-light);
 }
 
@@ -82,60 +83,62 @@
 	}
 }
 
-:host(:not([busy]):not([locked])[type='success']) .container {
+:host([type='success']) .container {
 	background-color: var(--ts-color-green);
 }
 
-:host(:not([busy]):not([locked])[type='success'][clickable]) .container:hover {
+:host([type='success'][clickable]) .container:hover {
 	background-color: var(--ts-color-green-dark);
 }
 
-:host(:not([busy]):not([locked])[type='warning']) .container {
+:host([type='warning']) .container {
 	background-color: var(--ts-color-orange);
 }
 
-:host(:not([busy]):not([locked])[type='warning'][clickable]) .container:hover {
+:host([type='warning'][clickable]) .container:hover {
 	background-color: var(--ts-color-orange-dark);
 }
 
-:host(:not([busy]):not([locked])[type='warning-lite']) .container {
+:host([type='warning-lite']) .container {
 	background-color: var(--ts-color-orange-lightest);
 }
 
-:host(:not([busy]):not([locked])[type='warning-lite'][clickable]) .container:hover {
+:host([type='warning-lite'][clickable]) .container:hover {
 	background-color: var(--ts-color-orange-lighter);
 }
 
-:host(:not([busy]):not([locked])[type='danger']) .container {
+:host([type='danger']) .container {
 	background-color: var(--ts-color-red);
 }
 
-:host(:not([busy]):not([locked])[type='danger'][clickable]) .container:hover {
+:host([type='danger'][clickable]) .container:hover {
 	background-color: var(--ts-color-red-dark);
 }
 
-:host(:not([busy]):not([locked])[type='blue']) .container {
+:host([type='blue']) .container {
 	background-color: var(--ts-color-blue);
 }
 
-:host(:not([busy]):not([locked])[type='blue'][clickable]) .container:hover {
+:host([type='blue'][clickable]) .container:hover {
 	background-color: var(--ts-color-blue-dark);
 }
 
-:host(:not([busy]):not([locked])[type='blue-lite']) .container {
+:host([type='blue-lite']) .container {
 	background-color: var(--ts-color-blue-lighter);
-	& .label,
-	& .value {
-		color: var(--ts-color-blue-dark);
-	}
+	color: var(--ts-color-blue-dark);
 }
 
-:host(:not([busy]):not([locked])[type='blue-lite'][clickable]) .container:hover {
+:host([type='blue-lite'][clickable]) .container:hover {
 	background-color: var(--ts-color-blue-light);
 }
 
 :host([locked]) .container {
-	color: var(--ts-color-slate-lightest);
+	background-color: var(--ts-color-gray-lighter);
+	color: var(--ts-color-slate-lightest) !important;
+}
+
+:host([clickable][locked]) .container:hover {
+	background-color: var(--ts-color-gray-light);
 }
 
 /* Specific clickable styles .....................................................*/

--- a/packages/components/tag/src/tag.css
+++ b/packages/components/tag/src/tag.css
@@ -82,80 +82,56 @@
 	}
 }
 
-:host(:not([busy]):not([locked])[type='success']) {
-	& .container {
-		background-color: var(--ts-color-green);
+:host(:not([busy]):not([locked])[type='success']) .container {
+	background-color: var(--ts-color-green);
+}
+
+:host(:not([busy]):not([locked])[type='success'][clickable]) .container:hover {
+	background-color: var(--ts-color-green-dark);
+}
+
+:host(:not([busy]):not([locked])[type='warning']) .container {
+	background-color: var(--ts-color-orange);
+}
+
+:host(:not([busy]):not([locked])[type='warning'][clickable]) .container:hover {
+	background-color: var(--ts-color-orange-dark);
+}
+
+:host(:not([busy]):not([locked])[type='warning-lite']) .container {
+	background-color: var(--ts-color-orange-lightest);
+}
+
+:host(:not([busy]):not([locked])[type='warning-lite'][clickable]) .container:hover {
+	background-color: var(--ts-color-orange-lighter);
+}
+
+:host(:not([busy]):not([locked])[type='danger']) .container {
+	background-color: var(--ts-color-red);
+}
+
+:host(:not([busy]):not([locked])[type='danger'][clickable]) .container:hover {
+	background-color: var(--ts-color-red-dark);
+}
+
+:host(:not([busy]):not([locked])[type='blue']) .container {
+	background-color: var(--ts-color-blue);
+}
+
+:host(:not([busy]):not([locked])[type='blue'][clickable]) .container:hover {
+	background-color: var(--ts-color-blue-dark);
+}
+
+:host(:not([busy]):not([locked])[type='blue-lite']) .container {
+	background-color: var(--ts-color-blue-lighter);
+	& .label,
+	& .value {
+		color: var(--ts-color-blue-dark);
 	}
 }
 
-:host(:not([busy]):not([locked])[type='success'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-green-dark);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='warning']) {
-	& .container {
-		background-color: var(--ts-color-orange);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='warning'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-orange-dark);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='warning-lite']) {
-	& .container {
-		background-color: var(--ts-color-orange-lightest);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='warning-lite'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-orange-lighter);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='danger']) {
-	& .container {
-		background-color: var(--ts-color-red);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='danger'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-red-dark);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='blue']) {
-	& .container {
-		background-color: var(--ts-color-blue);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='blue'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-blue-dark);
-	}
-}
-
-:host(:not([busy]):not([locked])[type='blue-lite']) {
-	& .container {
-		background-color: var(--ts-color-blue-lighter);
-		& .label,
-		& .value {
-			color: var(--ts-color-blue-dark);
-		}
-	}
-}
-
-:host(:not([busy]):not([locked])[type='blue-lite'][clickable]) {
-	& .container:hover {
-		background-color: var(--ts-color-blue-light);
-	}
+:host(:not([busy]):not([locked])[type='blue-lite'][clickable]) .container:hover {
+	background-color: var(--ts-color-blue-light);
 }
 
 :host([locked]) .container {
@@ -177,13 +153,7 @@
 :host([locked]),
 :host([deletable]) {
 	& .container {
-		padding-right: 0;
-	}
-}
-:host([locked]),
-:host([deletable]) {
-	& .container[dir='rtl'] {
-		padding-left: 0;
+		padding-inline-end: 0;
 	}
 }
 
@@ -202,29 +172,27 @@
 
 /* Busy status ....................................................*/
 
-:host([busy]) {
-	& > :first-child {
-		color: transparent;
-		font-style: unset;
-		pointer-events: none;
-		cursor: default;
-		box-shadow: none;
-		background-size: var(--ts-unit-double) var(--ts-unit-double);
-		background-image: linear-gradient(
-			-45deg,
-			var(--ts-color-gray-light) 25%,
-			var(--ts-color-gray-lightest) 25%,
-			var(--ts-color-gray-lightest) 50%,
-			var(--ts-color-gray-light) 50%,
-			var(--ts-color-gray-light) 75%,
-			var(--ts-color-gray-lightest) 75%,
-			var(--ts-color-gray-lightest)
-		);
-		animation: move 1s linear infinite;
+:host([busy]) > :first-child {
+	color: transparent;
+	font-style: unset;
+	pointer-events: none;
+	cursor: default;
+	box-shadow: none;
+	background-size: var(--ts-unit-double) var(--ts-unit-double);
+	background-image: linear-gradient(
+		-45deg,
+		var(--ts-color-gray-light) 25%,
+		var(--ts-color-gray-lightest) 25%,
+		var(--ts-color-gray-lightest) 50%,
+		var(--ts-color-gray-light) 50%,
+		var(--ts-color-gray-light) 75%,
+		var(--ts-color-gray-lightest) 75%,
+		var(--ts-color-gray-lightest)
+	);
+	animation: move 1s linear infinite;
 
-		& > * {
-			visibility: hidden;
-		}
+	& > * {
+		visibility: hidden;
 	}
 }
 

--- a/packages/components/tag/src/tag.js
+++ b/packages/components/tag/src/tag.js
@@ -102,13 +102,17 @@ export class TSTag extends TSElement {
 	}
 
 	render() {
+		// prettier-ignore
 		return html`<div
 			dir=${this.direction}
 			class=${this.classes}
 			@click=${this.handleClickEvent}
 			@keyup=${this.handleClickEvent}
 		>
-			${this._labels} ${this._separator} ${this._values} ${this._icons}
+			${this._labels}
+			${this._separator}
+			${this._values}
+			${this._icons}
 		</div>`;
 	}
 }

--- a/packages/components/tag/src/tag.js
+++ b/packages/components/tag/src/tag.js
@@ -63,7 +63,7 @@ export class TSTag extends TSElement {
 		return classList.filter(classname => classname).join(' ');
 	}
 
-	get icons() {
+	get _icons() {
 		if (this.locked) {
 			return html`
 				<span class="icon">
@@ -83,6 +83,24 @@ export class TSTag extends TSElement {
 		return null;
 	}
 
+	get _labels() {
+		if (this.labels) {
+			return html`<span class="label">${this.labels.join(', ')}</span>`;
+		}
+		return null;
+	}
+
+	get _separator() {
+		return this._hasBothLabelsAndValues() ? html`<span>:&nbsp;</span>` : null;
+	}
+
+	get _values() {
+		if (this.values) {
+			return html`<span class="value">${this.values.join(', ')}</span>`;
+		}
+		return null;
+	}
+
 	render() {
 		return html`<div
 			dir=${this.direction}
@@ -90,10 +108,7 @@ export class TSTag extends TSElement {
 			@click=${this.handleClickEvent}
 			@keyup=${this.handleClickEvent}
 		>
-			${this.labels &&
-			html`<span class="label">${this.labels.join(', ')}${this._hasBothLabelsAndValues() ? `:` : null}</span>`}
-			${this._hasBothLabelsAndValues() ? html`<span>&nbsp;</span>` : null}
-			${this.values && html`<span class="value">${this.values.join(', ')}</span>`} ${this.icons}
+			${this._labels} ${this._separator} ${this._values} ${this._icons}
 		</div>`;
 	}
 }


### PR DESCRIPTION
…ans up code a bit

https://tradeshift.atlassian.net/browse/PEAA-950

Uses a logical CSS selector for removing padding after an icon (locked and deletable tags have an icon at the end of the tag). Before the change, locked and deletable tags would have no padding at the right side of the tag in RTL mode; i.e. where the tag text/content begins. The padding-inline-end saves lines/rules compared to a solution controlling padding-right and padding-left.
The commit also cleans up a typo, removes unnecessary CSS rule nestings, and makes ts-tag element render code easier to read.