### PR TITLE
chore: updates package-lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-### Bug Fixes
-
-- removes import of non-existing export in plop template for auto-generating elements ([91203d6](https://github.com/Tradeshift/elements/commit/91203d63ce9788d7296bf866611eddc70efe5423))
-- **select:** do not set input value for multi select and no apply ([b5abd21](https://github.com/Tradeshift/elements/commit/b5abd2129c38e464a719f08b6b7bdaa8599635e6))
-- **select:** peaa-941 current selection clears on search input ([15b80ca](https://github.com/Tradeshift/elements/commit/15b80caaa96ace990e9616a317492c5d74397258))
-- **select:** show the `View selection` button in multi select with no apply ([c70c4f6](https://github.com/Tradeshift/elements/commit/c70c4f606e9b0548235e6ab539ed124acaa6fce3))
-
-### Features
-
-- adds ts-tag element ([ae9a078](https://github.com/Tradeshift/elements/commit/ae9a078cfd3f57fc030374f068edf3879b92a758))
-- **select:** add case-sensitive filtering to select component ([ee8182f](https://github.com/Tradeshift/elements/commit/ee8182f4ca559e2815d6ee4e54f638e20b528dec))
-- **select:** add custom filtering to select component ([690abf8](https://github.com/Tradeshift/elements/commit/690abf8ff1cd4164dcfead0d33e1d49c0f934cab))
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
 			"message": "chore(release): %s"
 		}
 	},
-	"version": "0.35.0"
+	"version": "0.34.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5766,14 +5766,12 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.18.2",
             "lowlight": "~1.11.0",
-            "prismjs": "^1.8.4",
+            "prismjs": ">=1.25.0",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.27.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-              "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+              "version": ">=1.25.0",
               "dev": true
             }
           }
@@ -5796,13 +5794,11 @@
           "requires": {
             "hastscript": "^5.0.0",
             "parse-entities": "^1.1.2",
-            "prismjs": "~1.17.0"
+            "prismjs": ">=1.25.0"
           },
           "dependencies": {
             "prismjs": {
-              "version": "1.27.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-              "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+              "version": ">=1.25.0",
               "dev": true
             }
           }
@@ -7460,18 +7456,8 @@
     "@tradeshift/elements.tag": {
       "version": "file:packages/components/tag",
       "requires": {
-        "@tradeshift/elements": "^0.33.8",
+        "@tradeshift/elements": "^0.34.0",
         "@tradeshift/elements.icon": "^0.34.0"
-      },
-      "dependencies": {
-        "@tradeshift/elements": {
-          "version": "0.33.8",
-          "resolved": "https://npm.pkg.github.com/download/@tradeshift/elements/0.33.8/e3da2e961c8dd2daa64457030584911fa1f87b14a34445493d9d7e12f7696dbf",
-          "integrity": "sha512-6mw2n+okA4yBi0xlHYNZxEEhF2gkilq1tl/R2tlCzJQYkCYjlnKJ7Zbq5p+Ga1PQw6NFAhsNepp12DNkhwOeLQ==",
-          "requires": {
-            "lit-element": "^2.4.0"
-          }
-        }
       }
     },
     "@tradeshift/elements.text-field": {
@@ -10226,7 +10212,7 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
+        "set-value": ">=4.0.1",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
@@ -10239,9 +10225,7 @@
           "dev": true
         },
         "set-value": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+          "version": ">=4.0.1",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",
@@ -24465,7 +24449,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "8.0.1",
+        "immer": ">=9.0.6",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -24539,9 +24523,7 @@
           }
         },
         "immer": {
-          "version": "9.0.12",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
-          "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
+          "version": ">=9.0.6",
           "dev": true
         },
         "ms": {
@@ -24713,14 +24695,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.1.1",
         "lowlight": "^1.14.0",
-        "prismjs": "^1.21.0",
+        "prismjs": ">=1.25.0",
         "refractor": "^3.1.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+          "version": ">=1.25.0",
           "dev": true
         }
       }
@@ -24961,13 +24941,11 @@
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.25.0"
+        "prismjs": ">=1.25.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+          "version": ">=1.25.0",
           "dev": true
         }
       }
@@ -25218,7 +25196,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
+        "trim": ">=0.0.3",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -25227,9 +25205,7 @@
       },
       "dependencies": {
         "trim": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
-          "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==",
+          "version": ">=0.0.3",
           "dev": true
         }
       }
@@ -28137,13 +28113,11 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "set-value": ">=4.0.1"
       },
       "dependencies": {
         "set-value": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+          "version": ">=4.0.1",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",

--- a/packages/components/action-select/CHANGELOG.md
+++ b/packages/components/action-select/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.action-select
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/action-select/package.json
+++ b/packages/components/action-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.action-select",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.overlay": "^0.35.0",
-    "@tradeshift/elements.select-menu": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.overlay": "^0.34.0",
+    "@tradeshift/elements.select-menu": "^0.34.0"
   },
   "src": "src/action-select.js"
 }

--- a/packages/components/app-icon/CHANGELOG.md
+++ b/packages/components/app-icon/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.app-icon
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.app-icon

--- a/packages/components/app-icon/package.json
+++ b/packages/components/app-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.app-icon",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/app-icon.js"
 }

--- a/packages/components/aside/CHANGELOG.md
+++ b/packages/components/aside/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.aside
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.aside

--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.aside",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.cover": "^0.35.0",
-    "@tradeshift/elements.spinner": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.cover": "^0.34.0",
+    "@tradeshift/elements.spinner": "^0.34.0"
   },
   "src": "src/aside.js"
 }

--- a/packages/components/basic-table/CHANGELOG.md
+++ b/packages/components/basic-table/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.basic-table
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.basic-table

--- a/packages/components/basic-table/package.json
+++ b/packages/components/basic-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.basic-table",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/basic-table.js"
 }

--- a/packages/components/board/CHANGELOG.md
+++ b/packages/components/board/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.board
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.board

--- a/packages/components/board/package.json
+++ b/packages/components/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.board",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/board.js"
 }

--- a/packages/components/button-group/CHANGELOG.md
+++ b/packages/components/button-group/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.button-group
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.button-group

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button-group",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/button-group.js"
 }

--- a/packages/components/button/CHANGELOG.md
+++ b/packages/components/button/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.button
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.button

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/button.js"
 }

--- a/packages/components/card/CHANGELOG.md
+++ b/packages/components/card/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.card
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.card

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.card",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/card.js"
 }

--- a/packages/components/checkbox/CHANGELOG.md
+++ b/packages/components/checkbox/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.checkbox
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.checkbox

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.checkbox",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/checkbox.js"
 }

--- a/packages/components/confirmation-prompt/CHANGELOG.md
+++ b/packages/components/confirmation-prompt/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.confirmation-prompt
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.confirmation-prompt

--- a/packages/components/confirmation-prompt/package.json
+++ b/packages/components/confirmation-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.confirmation-prompt",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.modal": "^0.35.0",
-    "@tradeshift/elements.text-field": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.modal": "^0.34.0",
+    "@tradeshift/elements.text-field": "^0.34.0"
   },
   "src": "src/confirmation-prompt.js"
 }

--- a/packages/components/cover/CHANGELOG.md
+++ b/packages/components/cover/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.cover
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.cover

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.cover",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/cover.js"
 }

--- a/packages/components/date-picker-overlay/CHANGELOG.md
+++ b/packages/components/date-picker-overlay/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.date-picker-overlay
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.date-picker-overlay

--- a/packages/components/date-picker-overlay/package.json
+++ b/packages/components/date-picker-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker-overlay",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/date-picker/CHANGELOG.md
+++ b/packages/components/date-picker/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.date-picker
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.date-picker-overlay": "^0.35.0",
-    "@tradeshift/elements.overlay": "^0.35.0",
-    "@tradeshift/elements.text-field": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.date-picker-overlay": "^0.34.0",
+    "@tradeshift/elements.overlay": "^0.34.0",
+    "@tradeshift/elements.text-field": "^0.34.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/dialog/CHANGELOG.md
+++ b/packages/components/dialog/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.dialog
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.dialog

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.dialog",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.button-group": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.modal": "^0.35.0",
-    "@tradeshift/elements.typography": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.button-group": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.modal": "^0.34.0",
+    "@tradeshift/elements.typography": "^0.34.0"
   },
   "src": "src/dialog.js"
 }

--- a/packages/components/document-card/CHANGELOG.md
+++ b/packages/components/document-card/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.document-card
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.document-card

--- a/packages/components/document-card/package.json
+++ b/packages/components/document-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.document-card",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/document-card.js"
 }

--- a/packages/components/file-card/CHANGELOG.md
+++ b/packages/components/file-card/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.file-card
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.file-card

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-card",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.card": "^0.35.0",
-    "@tradeshift/elements.file-size": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.progress-bar": "^0.35.0",
-    "@tradeshift/elements.typography": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.card": "^0.34.0",
+    "@tradeshift/elements.file-size": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.progress-bar": "^0.34.0",
+    "@tradeshift/elements.typography": "^0.34.0"
   },
   "src": "src/file-card.js"
 }

--- a/packages/components/file-size/CHANGELOG.md
+++ b/packages/components/file-size/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.file-size
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.file-size

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-size",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.typography": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.typography": "^0.34.0"
   },
   "src": "src/file-size.js"
 }

--- a/packages/components/file-uploader-input/CHANGELOG.md
+++ b/packages/components/file-uploader-input/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.file-uploader-input
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.file-uploader-input

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-uploader-input",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.help-text": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.help-text": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/file-uploader-input.js"
 }

--- a/packages/components/header/CHANGELOG.md
+++ b/packages/components/header/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.header
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.header

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.header",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.app-icon": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.app-icon": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/header.js"
 }

--- a/packages/components/help-text/CHANGELOG.md
+++ b/packages/components/help-text/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.help-text
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.help-text

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.help-text",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/help-text.js"
 }

--- a/packages/components/icon/CHANGELOG.md
+++ b/packages/components/icon/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.icon
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.icon

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.icon",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/icon.js"
 }

--- a/packages/components/input/CHANGELOG.md
+++ b/packages/components/input/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.input
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.input

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.input",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/input.js"
 }

--- a/packages/components/label/CHANGELOG.md
+++ b/packages/components/label/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.label
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.label

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.label",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/label.js"
 }

--- a/packages/components/list-item/CHANGELOG.md
+++ b/packages/components/list-item/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.list-item
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.list-item

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.list-item",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.typography": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.typography": "^0.34.0"
   },
   "src": "src/list-item.js"
 }

--- a/packages/components/modal/CHANGELOG.md
+++ b/packages/components/modal/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.modal
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.modal

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.modal",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.cover": "^0.35.0",
-    "@tradeshift/elements.header": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.cover": "^0.34.0",
+    "@tradeshift/elements.header": "^0.34.0"
   },
   "src": "src/modal.js"
 }

--- a/packages/components/note/CHANGELOG.md
+++ b/packages/components/note/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.note
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.note

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.note",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/note.js"
 }

--- a/packages/components/overlay/CHANGELOG.md
+++ b/packages/components/overlay/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.overlay
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.overlay

--- a/packages/components/overlay/package.json
+++ b/packages/components/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.overlay",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/overlay.js"
 }

--- a/packages/components/pager/CHANGELOG.md
+++ b/packages/components/pager/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.pager
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.pager

--- a/packages/components/pager/package.json
+++ b/packages/components/pager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.pager",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.tooltip": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.tooltip": "^0.34.0"
   },
   "src": "src/pager.js"
 }

--- a/packages/components/popover/CHANGELOG.md
+++ b/packages/components/popover/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.popover
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.popover

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.popover",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "src": "src/popover.js"
 }

--- a/packages/components/progress-bar/CHANGELOG.md
+++ b/packages/components/progress-bar/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.progress-bar
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.progress-bar",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/progress-bar.js"
 }

--- a/packages/components/radio-group/CHANGELOG.md
+++ b/packages/components/radio-group/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.radio-group
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.radio-group

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio-group",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.radio": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.radio": "^0.34.0"
   },
   "src": "src/radio-group.js"
 }

--- a/packages/components/radio/CHANGELOG.md
+++ b/packages/components/radio/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.radio
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.radio

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/radio.js"
 }

--- a/packages/components/root/CHANGELOG.md
+++ b/packages/components/root/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.root
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.root

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.root",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/root.js"
 }

--- a/packages/components/search/CHANGELOG.md
+++ b/packages/components/search/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.search
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.search",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.overlay": "^0.35.0",
-    "@tradeshift/elements.select-menu": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.overlay": "^0.34.0",
+    "@tradeshift/elements.select-menu": "^0.34.0"
   },
   "src": "src/search.js"
 }

--- a/packages/components/select-menu/CHANGELOG.md
+++ b/packages/components/select-menu/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-### Bug Fixes
-
-- **select:** peaa-941 current selection clears on search input ([15b80ca](https://github.com/Tradeshift/elements/commit/15b80caaa96ace990e9616a317492c5d74397258))
-- **select:** show the `View selection` button in multi select with no apply ([c70c4f6](https://github.com/Tradeshift/elements/commit/c70c4f606e9b0548235e6ab539ed124acaa6fce3))
-
-### Features
-
-- **select:** add case-sensitive filtering to select component ([ee8182f](https://github.com/Tradeshift/elements/commit/ee8182f4ca559e2815d6ee4e54f638e20b528dec))
-- **select:** add custom filtering to select component ([690abf8](https://github.com/Tradeshift/elements/commit/690abf8ff1cd4164dcfead0d33e1d49c0f934cab))
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Features

--- a/packages/components/select-menu/package.json
+++ b/packages/components/select-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select-menu",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.button": "^0.35.0",
-    "@tradeshift/elements.button-group": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.list-item": "^0.35.0",
-    "@tradeshift/elements.spinner": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.button": "^0.34.0",
+    "@tradeshift/elements.button-group": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.list-item": "^0.34.0",
+    "@tradeshift/elements.spinner": "^0.34.0"
   },
   "src": "src/select-menu.js"
 }

--- a/packages/components/select/CHANGELOG.md
+++ b/packages/components/select/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-### Bug Fixes
-
-- **select:** do not set input value for multi select and no apply ([b5abd21](https://github.com/Tradeshift/elements/commit/b5abd2129c38e464a719f08b6b7bdaa8599635e6))
-- **select:** peaa-941 current selection clears on search input ([15b80ca](https://github.com/Tradeshift/elements/commit/15b80caaa96ace990e9616a317492c5d74397258))
-
-### Features
-
-- **select:** add case-sensitive filtering to select component ([ee8182f](https://github.com/Tradeshift/elements/commit/ee8182f4ca559e2815d6ee4e54f638e20b528dec))
-- **select:** add custom filtering to select component ([690abf8](https://github.com/Tradeshift/elements/commit/690abf8ff1cd4164dcfead0d33e1d49c0f934cab))
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.overlay": "^0.35.0",
-    "@tradeshift/elements.select-menu": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.overlay": "^0.34.0",
+    "@tradeshift/elements.select-menu": "^0.34.0"
   },
   "src": "src/select.js"
 }

--- a/packages/components/spinner/CHANGELOG.md
+++ b/packages/components/spinner/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.spinner
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.spinner

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.spinner",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/spinner.js"
 }

--- a/packages/components/status/CHANGELOG.md
+++ b/packages/components/status/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.status
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.status

--- a/packages/components/status/package.json
+++ b/packages/components/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.status",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/status.js"
 }

--- a/packages/components/tab/CHANGELOG.md
+++ b/packages/components/tab/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.tab
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/tab/package.json
+++ b/packages/components/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tab",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/tab.js"
 }

--- a/packages/components/tabs/CHANGELOG.md
+++ b/packages/components/tabs/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.tabs
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 ### Bug Fixes

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tabs",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.icon": "^0.35.0",
-    "@tradeshift/elements.tab": "^0.35.0",
-    "@tradeshift/elements.typography": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.icon": "^0.34.0",
+    "@tradeshift/elements.tab": "^0.34.0",
+    "@tradeshift/elements.typography": "^0.34.0"
   },
   "src": "src/tabs.js"
 }

--- a/packages/components/tag/CHANGELOG.md
+++ b/packages/components/tag/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-### Features
-
-- adds ts-tag element ([ae9a078](https://github.com/Tradeshift/elements/commit/ae9a078cfd3f57fc030374f068edf3879b92a758))

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tag",
-  "version": "0.33.8",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.33.8",
+    "@tradeshift/elements": "^0.34.0",
     "@tradeshift/elements.icon": "^0.34.0"
   },
   "publishConfig": {

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tag",
-  "version": "0.35.0",
+  "version": "0.33.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@tradeshift/elements": "^0.33.8",
-    "@tradeshift/elements.icon": "^0.35.0"
+    "@tradeshift/elements.icon": "^0.34.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/text-field/CHANGELOG.md
+++ b/packages/components/text-field/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.text-field
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.text-field

--- a/packages/components/text-field/package.json
+++ b/packages/components/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.text-field",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0",
-    "@tradeshift/elements.help-text": "^0.35.0",
-    "@tradeshift/elements.input": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0",
+    "@tradeshift/elements.help-text": "^0.34.0",
+    "@tradeshift/elements.input": "^0.34.0"
   },
   "src": "src/text-field.js"
 }

--- a/packages/components/tooltip/CHANGELOG.md
+++ b/packages/components/tooltip/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.tooltip
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.tooltip

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tooltip",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/tooltip.js"
 }

--- a/packages/components/typography/CHANGELOG.md
+++ b/packages/components/typography/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements.typography
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements.typography

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.typography",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.35.0"
+    "@tradeshift/elements": "^0.34.0"
   },
   "src": "src/typography.js"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.35.0](https://github.com/Tradeshift/elements/compare/v0.34.0...v0.35.0) (2022-02-25)
-
-**Note:** Version bump only for package @tradeshift/elements
-
 # [0.34.0](https://github.com/Tradeshift/elements/compare/v0.33.8...v0.34.0) (2022-02-14)
 
 **Note:** Version bump only for package @tradeshift/elements

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements",
-  "version": "0.35.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",


### PR DESCRIPTION
I have deleted tags above 0.34.0, because the release build failed. For the same reason, the release commit for 0.35.0 has been reverted. This is to enable releasing a new version.