### PR TITLE
feat(button-group): peaa-885 button-group support horizontal/inline mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,6 +3,7 @@ body {
 	background-color: var(--ts-color-gray);
 	margin: 0;
 	padding: 0;
+	overflow: auto;
 }
 
 article {

--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
 					<a href="/packages/components/board/index.html">Board</a>
 				</li>
 				<li>
+					<a href="/packages/components/button-group/index.html">Button-Group</a>
+				</li>
+				<li>
 					<a href="/packages/components/date-picker/index.html">Date picker</a>
 				</li>
 				<li>

--- a/packages/components/button-group/README.md
+++ b/packages/components/button-group/README.md
@@ -31,8 +31,9 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| -------- | --------- | ---- | ------- | ----------- |
-|          |           |      |         |             |
+| --- | --- | --- | --- | --- |
+| dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
+| inline | inline | Boolean | false | Make the buttons inline instead of stacking which is the default behaviour |
 
 ## ➤ Slots
 

--- a/packages/components/button-group/index.html
+++ b/packages/components/button-group/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Tradeshift Elements: button-group</title>
+
+		<!-- Don't shim CSS Custom Properties on IE11 -->
+		<script>
+			if (!window.Promise) {
+				window.ShadyCSS = { nativeCss: true };
+			}
+		</script>
+
+		<!-- Enable ES5 class-less Custom Elements -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+		<!-- Load appropriate polyfills and shims -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+
+		<!-- Set :root CSS Custom Properties -->
+		<link rel="stylesheet" href="/packages/core/src/vars.css" />
+		<!-- Set @font-face for all needed fonts -->
+		<link rel="stylesheet" href="/packages/core/src/fonts.css" />
+		<!-- Set margin/padding to be 0 for <html> -->
+		<link rel="stylesheet" href="/packages/core/src/reset.css" />
+
+		<!-- Load user-styles -->
+		<link rel="stylesheet" href="/index.css" />
+
+		<script type="module" src="/packages/components/button/lib/button.esm.js"></script>
+		<script type="module" src="/packages/components/button-group/lib/button-group.esm.js"></script>
+		<script type="module" src="/packages/components/board/lib/board.esm.js"></script>
+	</head>
+
+	<body>
+		<article>
+			<ts-board data-title="ts-button-group">
+				<ts-button-group>
+					<ts-button type="primary">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="text" icon="ada">Action Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+				</ts-button-group>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-button-group">
+				<ts-button-group inline>
+					<ts-button type="primary">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="text" icon="ada">Action Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+					<ts-button type="primary" icon="ada">Icon Button – Grouped</ts-button>
+				</ts-button-group>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="sizes ts-button-group">
+				<ts-button-group inline>
+					<ts-button type="primary" size="micro">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary" size="micro">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary" size="micro">Secondary Button – Grouped</ts-button>
+					<ts-button type="text" size="micro">Text Button – Grouped</ts-button>
+					<ts-button type="text" icon="ada">Action Button – Grouped</ts-button>
+					<ts-button type="primary" size="micro" icon="ada">Icon Button – Grouped</ts-button>
+				</ts-button-group>
+				<ts-button-group>
+					<ts-button type="primary" size="micro">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary" size="micro">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary" size="micro">Secondary Button – Grouped</ts-button>
+					<ts-button type="text" size="micro">Text Button – Grouped</ts-button>
+					<ts-button type="text" size="micro" icon="ada">Action Button – Grouped</ts-button>
+					<ts-button type="primary" size="micro" icon="download">Icon Button – Grouped</ts-button>
+				</ts-button-group>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="RTL ts-button-group">
+				<ts-button-group inline dir="rtl">
+					<ts-button type="primary">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+				</ts-button-group>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="programmatically">
+				<label>
+					<input id="inlineSwitch" type="checkbox" />
+					Inline?
+				</label>
+				<hr />
+				<ts-button-group id="group">
+					<ts-button type="primary">Primary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="secondary">Secondary Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+					<ts-button type="text">Text Button – Grouped</ts-button>
+				</ts-button-group>
+				<script>
+					const inlineSwitch = document.getElementById('inlineSwitch');
+					const btnGroupEl = document.getElementById('group');
+					inlineSwitch.addEventListener('change', event => {
+						btnGroupEl.inline = event.target.checked;
+					});
+				</script>
+			</ts-board>
+		</article>
+	</body>
+</html>

--- a/packages/components/button-group/src/button-group.css
+++ b/packages/components/button-group/src/button-group.css
@@ -4,3 +4,11 @@
 	display: block;
 	width: 100%;
 }
+
+:host([inline]) {
+	font-size: 0;
+}
+
+:host([inline]) ::slotted(ts-button) {
+	margin-inline-end: var(--ts-unit-half);
+}

--- a/packages/components/button-group/src/button-group.js
+++ b/packages/components/button-group/src/button-group.js
@@ -6,23 +6,47 @@ export class TSButtonGroup extends TSElement {
 		return [TSElement.styles, unsafeCSS(css)];
 	}
 
+	static get properties() {
+		return {
+			/** Direction of the component 'rtl' or 'ltr' */
+			dir: { type: String, reflect: true },
+			/** Make the buttons inline instead of stacking which is the default behaviour */
+			inline: { type: Boolean, reflect: true }
+		};
+	}
+
+	get direction() {
+		return this.dir || this.bodyDir;
+	}
+
+	firstUpdated() {
+		this.updateButtonsProps();
+	}
+
+	handleSlotChange() {
+		this.updateButtonsProps();
+	}
+
+	update(changedProperties) {
+		super.update(changedProperties);
+		this.updateButtonsProps();
+	}
+
+	updateButtonsProps() {
+		Array.from(this.querySelectorAll('ts-button')).forEach(button => {
+			button.grouped = true;
+			button.inline = this.inline;
+			button.dir = this.dir;
+		});
+	}
+
 	render() {
 		return html`
-			<section>
+			<section dir="${this.direction}">
 				<!-- All \`ts-button\` elements in the group should be wrapped with \`ts-button-group\` element to be grouped together -->
 				<slot @slotchange="${this.handleSlotChange}"></slot>
 			</section>
 		`;
-	}
-
-	firstUpdated() {
-		this.handleSlotChange();
-	}
-
-	handleSlotChange() {
-		Array.from(this.querySelectorAll('ts-button')).forEach(button => {
-			button.grouped = true;
-		});
 	}
 }
 

--- a/packages/components/button-group/stories/button-group.happo.js
+++ b/packages/components/button-group/stories/button-group.happo.js
@@ -1,0 +1,86 @@
+import { html } from 'lit-html';
+import '@tradeshift/elements';
+import '@tradeshift/elements.button';
+import '@tradeshift/elements.button-group';
+import '@tradeshift/elements/src/vars.css';
+
+export default {
+	title: 'ts-button-group'
+};
+
+export const TestButtonGroup = () => {
+	return html`
+		<style>
+			.render-block {
+				flex: 0 0 40%;
+				border: 1px solid;
+				padding: 20px;
+			}
+		</style>
+		<div style="display: flex; flex-flow: row wrap; justify-content: space-between;">
+			<div class="render-block">
+				<p>Default</p>
+				<ts-button-group>
+					<ts-button type="primary">Primary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>inline</p>
+				<ts-button-group inline>
+					<ts-button type="primary">Primary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>inline RTL</p>
+				<ts-button-group inline dir="rtl">
+					<ts-button type="primary">Primary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>action button</p>
+				<ts-button-group>
+					<ts-button type="text" icon="ada">Action Button</ts-button>
+					<ts-button type="text" icon="lock">Action Button</ts-button>
+					<ts-button type="text" icon="search">Action Button</ts-button>
+					<ts-button type="text" icon="download">Action Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>action button RTL</p>
+				<ts-button-group dir="rtl">
+					<ts-button type="text" icon="ada">Action Button</ts-button>
+					<ts-button type="text" icon="lock">Action Button</ts-button>
+					<ts-button type="text" icon="search">Action Button</ts-button>
+					<ts-button type="text" icon="download">Action Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>inline action button</p>
+				<ts-button-group inline>
+					<ts-button type="text" icon="ada">Action Button</ts-button>
+					<ts-button type="text" icon="lock">Action Button</ts-button>
+					<ts-button type="text" icon="search">Action Button</ts-button>
+					<ts-button type="text" icon="download">Action Button</ts-button>
+				</ts-button-group>
+			</div>
+			<div class="render-block">
+				<p>inline action button RTL</p>
+				<ts-button-group inline dir="rtl">
+					<ts-button type="text" icon="ada">Action Button</ts-button>
+					<ts-button type="text" icon="lock">Action Button</ts-button>
+					<ts-button type="text" icon="search">Action Button</ts-button>
+					<ts-button type="text" icon="download">Action Button</ts-button>
+				</ts-button-group>
+			</div>
+		</div>
+	`;
+};

--- a/packages/components/button-group/stories/button-group.stories.js
+++ b/packages/components/button-group/stories/button-group.stories.js
@@ -1,20 +1,40 @@
 import { html } from 'lit-html';
 import '@tradeshift/elements';
+import '@tradeshift/elements.board';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.button-group';
 import readme from '../README.md';
+import { boolean, radios } from '@storybook/addon-knobs';
 
 export default {
 	title: 'ts-button-group'
 };
 
-export const Default = () => html`
-	<ts-button-group>
-		${['Primary', 'Secondary', 'Secondary', 'Secondary', 'Text', 'Text'].map(
-			type => html` <ts-button .type=${type.toLowerCase()}>${type} Button – Grouped</ts-button> `
-		)}
-	</ts-button-group>
-`;
+export const Default = () => {
+	const dir = radios('dir', { ltr: 'ltr', rtl: 'rtl' }, 'ltr');
+	const inline = boolean('inline', false);
+
+	return html`
+		<div style="display: flex; justify-content: space-around;">
+			<ts-board style="margin-bottom: 20px; width: 700px;">
+				<ts-button-group .dir="${dir}" ?inline="${inline}">
+					<ts-button type="primary">Primary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+					<ts-button type="secondary">Secondary Button</ts-button>
+				</ts-button-group>
+			</ts-board>
+			<ts-board style="margin-bottom: 20px; width: 700px;">
+				<ts-button-group .dir="${dir}" ?inline="${inline}">
+					<ts-button type="text" icon="ada">Action Button</ts-button>
+					<ts-button type="text" icon="download">Action Button</ts-button>
+					<ts-button type="text" icon="search">Action Button</ts-button>
+					<ts-button type="text" icon="lock">Action Button</ts-button>
+				</ts-button-group>
+			</ts-board>
+		</div>
+	`;
+};
 
 Default.story = {
 	name: 'default',

--- a/packages/components/button-group/types/button-group.d.ts
+++ b/packages/components/button-group/types/button-group.d.ts
@@ -1,5 +1,17 @@
 export interface TSButtonGroupHTMLAttributes {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Make the buttons inline instead of stacking which is the default behaviour  */
+	inline?: boolean;
+
 }
 
 export interface TSButtonGroup {
+	/**  Direction of the component 'rtl' or 'ltr'  */
+	dir?: string;
+
+	/**  Make the buttons inline instead of stacking which is the default behaviour  */
+	inline?: boolean;
+
 }

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -37,10 +37,11 @@
 | busy | busy | Boolean | false | Show busy/loading animation |
 | icon | icon | String |  | Icon name, see the list of available icons in ts-icon component. Also note that it will hide the slot content unless the type is text |
 | disabled | disabled | Boolean | false | Determine if the button is disabled. `button-click` event won't be dispatched |
-| grouped | grouped | Boolean | false | For internal use in `ts-button-group` component |
 | focused | focused | Boolean | false | Make the button focused |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
 | fullWidth | full-width | Boolean | false | Make the button take the full width of the container |
+| grouped | grouped | Boolean | false | INTERNAL For internal use in `ts-button-group` component |
+| inline | inline | Boolean | false | INTERNAL For internal use in `ts-button-group` component |
 
 ## ➤ Slots
 

--- a/packages/components/button/src/button.css
+++ b/packages/components/button/src/button.css
@@ -183,9 +183,11 @@
 
 :host([type='text'][icon]) {
 	& > button {
-		padding: var(--ts-unit-half);
+		padding-inline-start: var(--ts-unit-half);
+
 		& span {
 			color: var(--ts-color-blue-darkest);
+			padding: var(--ts-unit-half);
 		}
 	}
 }
@@ -240,6 +242,23 @@
 :host([grouped]) {
 	margin-bottom: var(--ts-unit-half);
 }
+
+:host([inline]) {
+	display: inline-block;
+
+	& > button {
+		width: auto;
+		display: inline;
+	}
+}
+
+:host([grouped][type='text']) {
+	& > button {
+		display: flex;
+		justify-content: center;
+	}
+}
+
 /* Button with an icon ............................................*/
 
 :host(:not([type='text'])[icon]) {
@@ -256,7 +275,7 @@
 	}
 
 	& span {
-		display: none;
+		visibility: hidden;
 	}
 }
 

--- a/packages/components/button/src/button.js
+++ b/packages/components/button/src/button.js
@@ -28,14 +28,16 @@ export class TSButton extends TSElement {
 			icon: { type: String, reflect: true },
 			/** Determine if the button is disabled. `button-click` event won't be dispatched */
 			disabled: { type: Boolean, reflect: true },
-			/** For internal use in `ts-button-group` component */
-			grouped: { type: Boolean, reflect: true },
 			/** Make the button focused */
 			focused: { type: Boolean, reflect: true },
 			/** Direction of the component 'rtl' or 'ltr' */
 			dir: { type: String, reflect: true },
 			/** Make the button take the full width of the container */
-			fullWidth: { type: Boolean, reflect: true, attribute: 'full-width' }
+			fullWidth: { type: Boolean, reflect: true, attribute: 'full-width' },
+			/** INTERNAL For internal use in `ts-button-group` component */
+			grouped: { type: Boolean, reflect: true },
+			/** INTERNAL For internal use in `ts-button-group` component */
+			inline: { type: Boolean, reflect: true }
 		};
 	}
 

--- a/packages/components/button/types/button.d.ts
+++ b/packages/components/button/types/button.d.ts
@@ -14,9 +14,6 @@ export interface TSButtonHTMLAttributes {
 	/**  Determine if the button is disabled. `button-click` event won't be dispatched  */
 	disabled?: boolean;
 
-	/**  For internal use in `ts-button-group` component  */
-	grouped?: boolean;
-
 	/**  Make the button focused  */
 	focused?: boolean;
 
@@ -43,9 +40,6 @@ export interface TSButton {
 
 	/**  Determine if the button is disabled. `button-click` event won't be dispatched  */
 	disabled?: boolean;
-
-	/**  For internal use in `ts-button-group` component  */
-	grouped?: boolean;
 
 	/**  Make the button focused  */
 	focused?: boolean;


### PR DESCRIPTION
Now it's possible to use the button-group in horizontal/inline mode with `inline`
property/attibute, which would make the buttons in the group aligned, margined
and wrapped properly.