### PR TITLE
feat(dialog): adds notification options to dialog element

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
 					<a href="/packages/components/date-picker/index.html">Date picker</a>
 				</li>
 				<li>
+					<a href="/packages/components/dialog/index.html">Dialog</a>
+				</li>
+				<li>
 					<a href="/packages/components/search/index.html">Search</a>
 				</li>
 				<li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5766,12 +5766,14 @@
             "@babel/runtime": "^7.3.1",
             "highlight.js": "~9.18.2",
             "lowlight": "~1.11.0",
-            "prismjs": ">=1.25.0",
+            "prismjs": "^1.8.4",
             "refractor": "^2.4.1"
           },
           "dependencies": {
             "prismjs": {
-              "version": ">=1.25.0",
+              "version": "1.27.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+              "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
               "dev": true
             }
           }
@@ -5794,11 +5796,13 @@
           "requires": {
             "hastscript": "^5.0.0",
             "parse-entities": "^1.1.2",
-            "prismjs": ">=1.25.0"
+            "prismjs": "~1.17.0"
           },
           "dependencies": {
             "prismjs": {
-              "version": ">=1.25.0",
+              "version": "1.27.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+              "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
               "dev": true
             }
           }
@@ -7159,325 +7163,325 @@
     "@tradeshift/elements.action-select": {
       "version": "file:packages/components/action-select",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.overlay": "^0.34.0",
-        "@tradeshift/elements.select-menu": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.overlay": "^0.35.0",
+        "@tradeshift/elements.select-menu": "^0.35.0"
       }
     },
     "@tradeshift/elements.app-icon": {
       "version": "file:packages/components/app-icon",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.aside": {
       "version": "file:packages/components/aside",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.cover": "^0.34.0",
-        "@tradeshift/elements.spinner": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.cover": "^0.35.0",
+        "@tradeshift/elements.spinner": "^0.35.0"
       }
     },
     "@tradeshift/elements.basic-table": {
       "version": "file:packages/components/basic-table",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.board": {
       "version": "file:packages/components/board",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.button-group": {
       "version": "file:packages/components/button-group",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.checkbox": {
       "version": "file:packages/components/checkbox",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.confirmation-prompt": {
       "version": "file:packages/components/confirmation-prompt",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.modal": "^0.34.0",
-        "@tradeshift/elements.text-field": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.modal": "^0.35.0",
+        "@tradeshift/elements.text-field": "^0.35.0"
       }
     },
     "@tradeshift/elements.cover": {
       "version": "file:packages/components/cover",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.date-picker": {
       "version": "file:packages/components/date-picker",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.date-picker-overlay": "^0.34.0",
-        "@tradeshift/elements.overlay": "^0.34.0",
-        "@tradeshift/elements.text-field": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.date-picker-overlay": "^0.35.0",
+        "@tradeshift/elements.overlay": "^0.35.0",
+        "@tradeshift/elements.text-field": "^0.35.0"
       }
     },
     "@tradeshift/elements.date-picker-overlay": {
       "version": "file:packages/components/date-picker-overlay",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.dialog": {
       "version": "file:packages/components/dialog",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.button-group": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.modal": "^0.34.0",
-        "@tradeshift/elements.typography": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.button-group": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.modal": "^0.35.0",
+        "@tradeshift/elements.typography": "^0.35.0"
       }
     },
     "@tradeshift/elements.document-card": {
       "version": "file:packages/components/document-card",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.file-card": {
       "version": "file:packages/components/file-card",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.card": "^0.34.0",
-        "@tradeshift/elements.file-size": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.progress-bar": "^0.34.0",
-        "@tradeshift/elements.typography": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.card": "^0.35.0",
+        "@tradeshift/elements.file-size": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.progress-bar": "^0.35.0",
+        "@tradeshift/elements.typography": "^0.35.0"
       }
     },
     "@tradeshift/elements.file-size": {
       "version": "file:packages/components/file-size",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.typography": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.typography": "^0.35.0"
       }
     },
     "@tradeshift/elements.file-uploader-input": {
       "version": "file:packages/components/file-uploader-input",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.help-text": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.help-text": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.app-icon": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.app-icon": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.help-text": {
       "version": "file:packages/components/help-text",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.input": {
       "version": "file:packages/components/input",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.label": {
       "version": "file:packages/components/label",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.list-item": {
       "version": "file:packages/components/list-item",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.typography": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.typography": "^0.35.0"
       }
     },
     "@tradeshift/elements.modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.cover": "^0.34.0",
-        "@tradeshift/elements.header": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.cover": "^0.35.0",
+        "@tradeshift/elements.header": "^0.35.0"
       }
     },
     "@tradeshift/elements.note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.overlay": {
       "version": "file:packages/components/overlay",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.pager": {
       "version": "file:packages/components/pager",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.tooltip": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.tooltip": "^0.35.0"
       }
     },
     "@tradeshift/elements.popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.progress-bar": {
       "version": "file:packages/components/progress-bar",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.radio": {
       "version": "file:packages/components/radio",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.radio-group": {
       "version": "file:packages/components/radio-group",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.radio": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.radio": "^0.35.0"
       }
     },
     "@tradeshift/elements.root": {
       "version": "file:packages/components/root",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.search": {
       "version": "file:packages/components/search",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.overlay": "^0.34.0",
-        "@tradeshift/elements.select-menu": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.overlay": "^0.35.0",
+        "@tradeshift/elements.select-menu": "^0.35.0"
       }
     },
     "@tradeshift/elements.select": {
       "version": "file:packages/components/select",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.overlay": "^0.34.0",
-        "@tradeshift/elements.select-menu": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.overlay": "^0.35.0",
+        "@tradeshift/elements.select-menu": "^0.35.0"
       }
     },
     "@tradeshift/elements.select-menu": {
       "version": "file:packages/components/select-menu",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.button": "^0.34.0",
-        "@tradeshift/elements.button-group": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.list-item": "^0.34.0",
-        "@tradeshift/elements.spinner": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.button": "^0.35.0",
+        "@tradeshift/elements.button-group": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.list-item": "^0.35.0",
+        "@tradeshift/elements.spinner": "^0.35.0"
       }
     },
     "@tradeshift/elements.spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.status": {
       "version": "file:packages/components/status",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.tab": {
       "version": "file:packages/components/tab",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0",
-        "@tradeshift/elements.tab": "^0.34.0",
-        "@tradeshift/elements.typography": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0",
+        "@tradeshift/elements.tab": "^0.35.0",
+        "@tradeshift/elements.typography": "^0.35.0"
       }
     },
     "@tradeshift/elements.tag": {
       "version": "file:packages/components/tag",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.icon": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.icon": "^0.35.0"
       }
     },
     "@tradeshift/elements.text-field": {
       "version": "file:packages/components/text-field",
       "requires": {
-        "@tradeshift/elements": "^0.34.0",
-        "@tradeshift/elements.help-text": "^0.34.0",
-        "@tradeshift/elements.input": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0",
+        "@tradeshift/elements.help-text": "^0.35.0",
+        "@tradeshift/elements.input": "^0.35.0"
       }
     },
     "@tradeshift/elements.tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@tradeshift/elements.typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@tradeshift/elements": "^0.34.0"
+        "@tradeshift/elements": "^0.35.0"
       }
     },
     "@trysound/sax": {
@@ -10212,7 +10216,7 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": ">=4.0.1",
+        "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
@@ -10225,7 +10229,9 @@
           "dev": true
         },
         "set-value": {
-          "version": ">=4.0.1",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",
@@ -24449,7 +24455,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": ">=9.0.6",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -24523,7 +24529,9 @@
           }
         },
         "immer": {
-          "version": ">=9.0.6",
+          "version": "9.0.12",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+          "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
           "dev": true
         },
         "ms": {
@@ -24695,12 +24703,14 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.1.1",
         "lowlight": "^1.14.0",
-        "prismjs": ">=1.25.0",
+        "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": ">=1.25.0",
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
           "dev": true
         }
       }
@@ -24941,11 +24951,13 @@
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": ">=1.25.0"
+        "prismjs": "~1.25.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": ">=1.25.0",
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
           "dev": true
         }
       }
@@ -25196,7 +25208,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": ">=0.0.3",
+        "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -25205,7 +25217,9 @@
       },
       "dependencies": {
         "trim": {
-          "version": ">=0.0.3",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
+          "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==",
           "dev": true
         }
       }
@@ -28113,11 +28127,13 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": ">=4.0.1"
+        "set-value": "^2.0.1"
       },
       "dependencies": {
         "set-value": {
-          "version": ">=4.0.1",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+          "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4",

--- a/packages/components/dialog/README.md
+++ b/packages/components/dialog/README.md
@@ -32,13 +32,16 @@
 
 | Property | Attribute | Type | Default | Description |
 | --- | --- | --- | --- | --- |
-| visible | data-visible | Boolean | false | Dialog can be toggled by add/removing this attribute |
+| visible | data-visible | Boolean | false | Dialog can be toggled by adding/removing this attribute |
 | text | text | String |  | Text content of the modal |
-| icon | icon | String |  | If you need a different icon that default ones, you can use one of Elements icon names |
-| type | type | String | dialogTypes.CONFIRM | `confirm`, `warning`, `danger` |
+| icon | icon | String |  | If you need a different icon that default ones, you can use one of Elements icon names. Notifications will ignore this |
+| type | type | String | dialogTypes.CONFIRM | `success`, `info`, `confirm`, `warning`, `danger`, `error` |
 | translations | translations | Object |  | can be used for customizing the buttons text and translations |
 | focused | focused | String | 'cancel' | set the default focus on the button, either `accept` or `cancel` |
 | primary | primary | String |  | either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary |
+| notification | notification | Boolean | false | If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable` |
+| noButtons | no-buttons | Boolean | false | Render no buttons. This only affects notifications of type 'success' |
+| nonDismissable | non-dismissable | Boolean | false | Cannot be dismissed. This only affect notifications |
 | renderButtons | renderButtons | Boolean | false | INTERNAL |
 
 ## ➤ Slots
@@ -46,7 +49,7 @@
 | Name | Description |
 | --- | --- |
 | content | If in rare cases you need to have more complex content than text property, you can override the text by using this slot |
-| extra-buttons | To add more options to the dialog, between accept and cancel buttons |
+| extra-buttons |  |
 
 ## ➤ Events
 

--- a/packages/components/dialog/README.md
+++ b/packages/components/dialog/README.md
@@ -40,7 +40,6 @@
 | focused | focused | String | 'cancel' | set the default focus on the button, either `accept` or `cancel` |
 | primary | primary | String |  | either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary |
 | notification | notification | Boolean | false | If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable` |
-| noButtons | no-buttons | Boolean | false | Render no buttons. This only affects notifications of type 'success' |
 | nonDismissable | non-dismissable | Boolean | false | Cannot be dismissed except by clicking available buttons in the dialog/notification |
 | renderButtons | renderButtons | Boolean | false | INTERNAL |
 
@@ -49,7 +48,7 @@
 | Name | Description |
 | --- | --- |
 | content | If in rare cases you need to have more complex content than text property, you can override the text by using this slot |
-| extra-buttons |  |
+| extra-buttons | To add more options to the dialog (notifications will ignore extra buttons), between accept and cancel buttons |
 
 ## ➤ Events
 

--- a/packages/components/dialog/README.md
+++ b/packages/components/dialog/README.md
@@ -41,7 +41,7 @@
 | primary | primary | String |  | either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary |
 | notification | notification | Boolean | false | If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable` |
 | noButtons | no-buttons | Boolean | false | Render no buttons. This only affects notifications of type 'success' |
-| nonDismissable | non-dismissable | Boolean | false | Cannot be dismissed. This only affect notifications |
+| nonDismissable | non-dismissable | Boolean | false | Cannot be dismissed except by clicking available buttons in the dialog/notification |
 | renderButtons | renderButtons | Boolean | false | INTERNAL |
 
 ## ➤ Slots

--- a/packages/components/dialog/index.html
+++ b/packages/components/dialog/index.html
@@ -70,23 +70,30 @@
 
 	<body>
 		<article>
-			<ts-board data-title="ts-tag, multiple in a flexbox">
+			<ts-board data-title="ts-dialog">
 				<div>
-					<button onclick="javascript:makeNotifications()">Make notifications</button>
-					<button onclick="javascript:makeDialogs()">Make dialogs</button>
+					<h3>Make All</h3>
+					<button onclick="makeNotifications()">notifications</button>
+					<button onclick="makeDialogs()">dialogs</button>
 				</div>
-				<br />
 				<div>
-					<button onclick="javascript:toggleDialog('success')">Toggle success</button>
-					<button onclick="javascript:toggleDialog('info')">Toggle info</button>
-					<button onclick="javascript:toggleDialog('confirm')">Toggle confirm</button>
-					<button onclick="javascript:toggleDialog('warning')">Toggle warning</button>
-					<button onclick="javascript:toggleDialog('danger')">Toggle danger</button>
-					<button onclick="javascript:toggleDialog('error')">Toggle error</button>
-					<button onclick="javascript:toggleDialog('extrabuttons')">With extra buttons</button>
-					<button onclick="javascript:toggleDialog('extrabuttonssuccess')">
-						With extra buttons, but success no-buttons (works as notification)
+					<h3>Toggle</h3>
+					<button onclick="toggleDialog('success')">success</button>
+					<button onclick="toggleDialog('info')">info</button>
+					<button onclick="toggleDialog('confirm')">confirm</button>
+					<button onclick="toggleDialog('warning')">warning</button>
+					<button onclick="toggleDialog('danger')">danger</button>
+					<button onclick="toggleDialog('error')">error</button>
+					<button onclick="toggleDialog('extrabuttons')">with extra buttons</button>
+					<button onclick="toggleDialog('extrabuttonssuccess')">
+						with extra buttons, but success no-buttons (works as notification)
 					</button>
+				</div>
+				<div>
+					<h3>Non-dismissable</h3>
+					<button onclick="toggleDialog('non-dismissable-success')">non-dismissable success</button>
+					<button onclick="toggleDialog('non-dismissable-info')">non-dismissable info</button>
+					<button onclick="toggleDialog('non-dismissable-no-buttons')">non-dismissable warning, no-buttons</button>
 				</div>
 				<ts-dialog
 					id="success"
@@ -102,7 +109,7 @@
 				<ts-dialog id="danger" text="danger 😱" type="danger" primary="accept">
 					<div slot="content">Render in "content" slot.</div>
 				</ts-dialog>
-				<ts-dialog id="error" text="error 💥" type="error" primary="accept" non-dismissable></ts-dialog>
+				<ts-dialog id="error" text="error 💥" type="error" primary="accept"></ts-dialog>
 				<ts-dialog id="extrabuttons" text="has extra buttons" type="info" primary="accept" no-buttons>
 					<ts-button-group slot="extra-buttons">
 						<ts-button type="danger">another action</ts-button>
@@ -121,6 +128,28 @@
 						<ts-button type="primary">primary action</ts-button>
 					</ts-button-group>
 				</ts-dialog>
+				<ts-dialog
+					id="non-dismissable-success"
+					text="non-dismissable success"
+					type="success"
+					primary="accept"
+					non-dismissable
+				></ts-dialog>
+				<ts-dialog
+					id="non-dismissable-info"
+					text="non-dismissable info"
+					type="info"
+					primary="accept"
+					non-dismissable
+				></ts-dialog>
+				<ts-dialog
+					id="non-dismissable-no-buttons"
+					text="non-dismissable info"
+					type="info"
+					primary="accept"
+					non-dismissable
+					no-buttons
+				></ts-dialog>
 			</ts-board>
 		</article>
 	</body>

--- a/packages/components/dialog/index.html
+++ b/packages/components/dialog/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Tradeshift Elements - dialog</title>
+
+		<!-- Don't shim CSS Custom Properties on IE11 -->
+		<script>
+			if (!window.Promise) {
+				window.ShadyCSS = { nativeCss: true };
+			}
+		</script>
+
+		<!-- Enable ES5 class-less Custom Elements -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+		<!-- Load appropriate polyfills and shims -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+
+		<!-- Set :root CSS Custom Properties -->
+		<link rel="stylesheet" href="/packages/core/src/vars.css" />
+		<!-- Set @font-face for all needed fonts -->
+		<link rel="stylesheet" href="/packages/core/src/fonts.css" />
+		<!-- Set margin/padding to be 0 for <html> -->
+		<link rel="stylesheet" href="/packages/core/src/reset.css" />
+
+		<!-- Load user-styles -->
+		<link rel="stylesheet" href="/index.css" />
+
+		<script type="module" src="/packages/components/dialog/lib/dialog.esm.js"></script>
+		<script type="module" src="/packages/components/board/lib/board.esm.js"></script>
+		<script>
+			function toggleDialog(id) {
+				if (!id) {
+					console.error('no dialog id provided');
+					return;
+				}
+				const dialog = document.querySelector(`#${id}`);
+				if (!dialog) {
+					console.error('dialog id not found in DOM');
+					return;
+				}
+				if ('visible' in dialog.dataset) {
+					dialog.removeAttribute('data-visible');
+					return;
+				}
+				dialog.setAttribute('data-visible', '');
+			}
+
+			window.addEventListener('accept', event => {
+				console.log('accept');
+			});
+			window.addEventListener('cancel', event => {
+				console.log('cancel');
+			});
+			function makeNotifications() {
+				const dialogs = document.querySelectorAll('ts-dialog');
+				dialogs.forEach(dialog => {
+					dialog.setAttribute('notification', 'true');
+				});
+			}
+			function makeDialogs() {
+				const dialogs = document.querySelectorAll('ts-dialog');
+				dialogs.forEach(dialog => {
+					dialog.removeAttribute('notification');
+				});
+			}
+		</script>
+	</head>
+
+	<body>
+		<article>
+			<ts-board data-title="ts-tag, multiple in a flexbox">
+				<div>
+					<button onclick="javascript:makeNotifications()">Make notifications</button>
+					<button onclick="javascript:makeDialogs()">Make dialogs</button>
+				</div>
+				<br />
+				<div>
+					<button onclick="javascript:toggleDialog('success')">Toggle success</button>
+					<button onclick="javascript:toggleDialog('info')">Toggle info</button>
+					<button onclick="javascript:toggleDialog('confirm')">Toggle confirm</button>
+					<button onclick="javascript:toggleDialog('warning')">Toggle warning</button>
+					<button onclick="javascript:toggleDialog('danger')">Toggle danger</button>
+					<button onclick="javascript:toggleDialog('error')">Toggle error</button>
+					<button onclick="javascript:toggleDialog('extrabuttons')">With extra buttons</button>
+					<button onclick="javascript:toggleDialog('extrabuttonssuccess')">
+						With extra buttons, but success no-buttons (works as notification)
+					</button>
+				</div>
+				<ts-dialog
+					id="success"
+					text="success 🎉"
+					type="success"
+					primary="accept"
+					focused="accept"
+					icon="discovery"
+				></ts-dialog>
+				<ts-dialog id="info" text="info 💁🏻‍♀️" type="info" primary="accept"></ts-dialog>
+				<ts-dialog id="confirm" text="confirm ✓" type="confirm" primary="accept"></ts-dialog>
+				<ts-dialog id="warning" text="warning ⚠️" type="warning" primary="accept"></ts-dialog>
+				<ts-dialog id="danger" text="danger 😱" type="danger" primary="accept">
+					<div slot="content">Render in "content" slot.</div>
+				</ts-dialog>
+				<ts-dialog id="error" text="error 💥" type="error" primary="accept" non-dismissable></ts-dialog>
+				<ts-dialog id="extrabuttons" text="has extra buttons" type="info" primary="accept" no-buttons>
+					<ts-button-group slot="extra-buttons">
+						<ts-button type="danger">another action</ts-button>
+						<ts-button type="primary">primary action</ts-button>
+					</ts-button-group>
+				</ts-dialog>
+				<ts-dialog
+					id="extrabuttonssuccess"
+					text="has extra buttons, but no-buttons"
+					type="success"
+					primary="accept"
+					no-buttons
+				>
+					<ts-button-group slot="extra-buttons">
+						<ts-button type="danger">another action</ts-button>
+						<ts-button type="primary">primary action</ts-button>
+					</ts-button-group>
+				</ts-dialog>
+			</ts-board>
+		</article>
+	</body>
+</html>

--- a/packages/components/dialog/index.html
+++ b/packages/components/dialog/index.html
@@ -85,15 +85,12 @@
 					<button onclick="toggleDialog('danger')">danger</button>
 					<button onclick="toggleDialog('error')">error</button>
 					<button onclick="toggleDialog('extrabuttons')">with extra buttons</button>
-					<button onclick="toggleDialog('extrabuttonssuccess')">
-						with extra buttons, but success no-buttons (works as notification)
-					</button>
+					<button onclick="toggleDialog('extrabuttonssuccess')">success with extra buttons</button>
 				</div>
 				<div>
 					<h3>Non-dismissable</h3>
 					<button onclick="toggleDialog('non-dismissable-success')">non-dismissable success</button>
 					<button onclick="toggleDialog('non-dismissable-info')">non-dismissable info</button>
-					<button onclick="toggleDialog('non-dismissable-no-buttons')">non-dismissable warning, no-buttons</button>
 				</div>
 				<ts-dialog
 					id="success"
@@ -110,19 +107,13 @@
 					<div slot="content">Render in "content" slot.</div>
 				</ts-dialog>
 				<ts-dialog id="error" text="error 💥" type="error" primary="accept"></ts-dialog>
-				<ts-dialog id="extrabuttons" text="has extra buttons" type="info" primary="accept" no-buttons>
+				<ts-dialog id="extrabuttons" text="has extra buttons" type="info" primary="accept">
 					<ts-button-group slot="extra-buttons">
 						<ts-button type="danger">another action</ts-button>
 						<ts-button type="primary">primary action</ts-button>
 					</ts-button-group>
 				</ts-dialog>
-				<ts-dialog
-					id="extrabuttonssuccess"
-					text="has extra buttons, but no-buttons"
-					type="success"
-					primary="accept"
-					no-buttons
-				>
+				<ts-dialog id="extrabuttonssuccess" text="has extra buttons" type="success" primary="accept">
 					<ts-button-group slot="extra-buttons">
 						<ts-button type="danger">another action</ts-button>
 						<ts-button type="primary">primary action</ts-button>
@@ -141,14 +132,6 @@
 					type="info"
 					primary="accept"
 					non-dismissable
-				></ts-dialog>
-				<ts-dialog
-					id="non-dismissable-no-buttons"
-					text="non-dismissable info"
-					type="info"
-					primary="accept"
-					non-dismissable
-					no-buttons
 				></ts-dialog>
 			</ts-board>
 		</article>

--- a/packages/components/dialog/src/dialog.css
+++ b/packages/components/dialog/src/dialog.css
@@ -1,8 +1,3 @@
-/* General........................................................ */
-
-:host {
-}
-
 .content {
 	text-align: center;
 	padding: 0 var(--ts-unit) var(--ts-unit);
@@ -10,16 +5,6 @@
 
 .footer {
 	padding: 0 var(--ts-unit-double) var(--ts-unit);
-}
-
-::slotted(ts-button) {
-	display: block;
-	margin-bottom: var(--ts-unit-half);
-	text-align: center;
-}
-
-ts-button:focus {
-	box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
 }
 
 .visuallyhidden {

--- a/packages/components/dialog/src/dialog.css
+++ b/packages/components/dialog/src/dialog.css
@@ -21,3 +21,14 @@
 ts-button:focus {
 	box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
 }
+
+.visuallyhidden {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}

--- a/packages/components/dialog/src/dialog.js
+++ b/packages/components/dialog/src/dialog.js
@@ -1,4 +1,11 @@
-import { TSElement, unsafeCSS, html, customElementDefineHelper, validateSlottedNodes } from '@tradeshift/elements';
+import {
+	TSElement,
+	unsafeCSS,
+	html,
+	customElementDefineHelper,
+	validateSlottedNodes,
+	constants
+} from '@tradeshift/elements';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.button-group';
 import '@tradeshift/elements.icon';
@@ -14,6 +21,8 @@ export class TSDialog extends TSElement {
 		this.type = dialogTypes.CONFIRM;
 		this.focused = 'cancel';
 		this._translations = Object.assign({}, translations);
+		this.notification = false;
+		this.nonDismissable = false;
 	}
 
 	static get styles() {
@@ -22,13 +31,13 @@ export class TSDialog extends TSElement {
 
 	static get properties() {
 		return {
-			/** Dialog can be toggled by add/removing this attribute */
+			/** Dialog can be toggled by adding/removing this attribute */
 			visible: { type: Boolean, attribute: 'data-visible', reflect: true },
 			/** Text content of the modal */
 			text: { type: String, reflect: true },
-			/** If you need a different icon that default ones, you can use one of Elements icon names */
+			/** If you need a different icon that default ones, you can use one of Elements icon names. Notifications will ignore this */
 			icon: { type: String, reflect: true },
-			/** `confirm`, `warning`, `danger` */
+			/** `success`, `info`, `confirm`, `warning`, `danger`, `error` */
 			type: { type: String, reflect: true },
 			/** can be used for customizing the buttons text and translations */
 			translations: { type: Object, reflect: true },
@@ -36,6 +45,12 @@ export class TSDialog extends TSElement {
 			focused: { type: String, reflect: true },
 			/** either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary */
 			primary: { type: String, reflect: true },
+			/** If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable` */
+			notification: { type: Boolean, reflect: true },
+			/** Render no buttons. This only affects notifications of type 'success' */
+			noButtons: { type: Boolean, reflect: true, attribute: 'no-buttons' },
+			/** Cannot be dismissed. This only affect notifications */
+			nonDismissable: { type: Boolean, reflect: true, attribute: 'non-dismissable' },
 			/** INTERNAL */
 			renderButtons: { type: Boolean, attribute: false }
 		};
@@ -52,7 +67,7 @@ export class TSDialog extends TSElement {
 	}
 
 	get getIcon() {
-		return this.icon ? this.icon : dialogTypeIcon[this.type];
+		return this.icon && !this.notification ? this.icon : dialogTypeIcon[this.type];
 	}
 
 	get getIconType() {
@@ -69,12 +84,24 @@ export class TSDialog extends TSElement {
 
 	attributeChangedCallback(name, oldVal, newVal) {
 		super.attributeChangedCallback(name, oldVal, newVal);
-		if (name === 'data-visible' && newVal) {
+		if (name === 'data-visible' && typeof newVal === 'string') {
 			// FIXME: this.updateComplete didn't work for this case
 			// Needed to render buttons a bit later to be able to set focus on them
 			window.setTimeout(() => {
 				this.renderButtons = true;
 			}, 200);
+		}
+	}
+
+	updated(changedProps) {
+		super.updated(changedProps);
+		if (changedProps.has('visible') && this.visible === true) {
+			/** close dismissable success notifications after a timeout */
+			if (this.notification === true && this.type === dialogTypes.SUCCESS && !this.nonDismissable) {
+				return window.setTimeout(() => {
+					this.dismissModal();
+				}, constants.delay.CLOSE);
+			}
 		}
 	}
 
@@ -105,12 +132,35 @@ export class TSDialog extends TSElement {
 	}
 
 	isFocused(buttonType) {
+		if (this.nonDismissable) {
+			return false;
+		}
+		if (this.notification) {
+			if (buttonType === 'accept') {
+				return true;
+			}
+			return false;
+		}
 		return this.renderButtons && this.focused === buttonType;
+	}
+
+	get _hideAllButtons() {
+		return this.noButtons && this.notification && this.type === dialogTypes.SUCCESS;
+	}
+
+	get _nonDismissable() {
+		return this.notification && this.nonDismissable;
 	}
 
 	render() {
 		return html`
-			<ts-modal ?data-visible=${this.visible} data-size="small" hide-header>
+			<ts-modal
+				?data-visible=${this.visible}
+				data-size="small"
+				hide-header
+				?no-close-on-esc-key=${this._nonDismissable}
+				?no-close-on-cover-click=${this._nonDismissable}
+			>
 				<div class="content" slot="main">
 					<ts-icon icon="${this.getIcon}" type="${this.getIconType}" size="extra-large"></ts-icon>
 					<!-- If in rare cases you need to have more complex content than text property, you can override the text by using this slot	-->
@@ -118,7 +168,7 @@ export class TSDialog extends TSElement {
 						<ts-typography>${this.text}</ts-typography>
 					</slot>
 				</div>
-				<div class="footer" slot="footer">
+				<div class="footer${this._hideAllButtons ? ' visuallyhidden' : ''}" slot="footer">
 					<ts-button-group>
 						<ts-button
 							?focused="${this.isFocused('accept')}"
@@ -127,12 +177,15 @@ export class TSDialog extends TSElement {
 						>
 							${this.translations.accept_button}
 						</ts-button>
-						<!-- To add more options to the dialog, between accept and cancel buttons  	-->
-						<slot name="extra-buttons" @slotchange="${this.extraButtonsSlotChangeHandler}"></slot>
+						<!-- To add more options to the dialog (notifications will ignore extra buttons), between accept and cancel buttons  	-->
+						<div class="${this.notification ? 'visuallyhidden' : ''}">
+							<slot name="extra-buttons" @slotchange="${this.extraButtonsSlotChangeHandler}"></slot>
+						</div>
 						<ts-button
 							?focused="${this.isFocused('cancel')}"
 							@click="${this.onCancel}"
 							type="${this.getCancelButtonType}"
+							class="${this.notification ? 'visuallyhidden' : ''}"
 						>
 							${this.translations.cancel_button}
 						</ts-button>

--- a/packages/components/dialog/src/dialog.js
+++ b/packages/components/dialog/src/dialog.js
@@ -1,11 +1,4 @@
-import {
-	TSElement,
-	unsafeCSS,
-	html,
-	customElementDefineHelper,
-	validateSlottedNodes,
-	constants
-} from '@tradeshift/elements';
+import { TSElement, unsafeCSS, html, customElementDefineHelper, validateSlottedNodes } from '@tradeshift/elements';
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.button-group';
 import '@tradeshift/elements.icon';
@@ -13,7 +6,7 @@ import '@tradeshift/elements.modal';
 import '@tradeshift/elements.typography';
 
 import css from './dialog.css';
-import { translations, dialogTypes, dialogTypeIcon, dialogTypeIconTypes, dialogTypeButtonType } from './utils';
+import { translations, dialogTypes, dialogTypeIcon, dialogTypeIconTypes, dialogTypeButtonType, timeout } from './utils';
 
 export class TSDialog extends TSElement {
 	constructor() {
@@ -98,7 +91,7 @@ export class TSDialog extends TSElement {
 			if (this.notification === true && this.type === dialogTypes.SUCCESS && !this.nonDismissable) {
 				return window.setTimeout(() => {
 					this.dismissModal();
-				}, constants.delay.CLOSE);
+				}, timeout);
 			}
 		}
 	}

--- a/packages/components/dialog/src/dialog.js
+++ b/packages/components/dialog/src/dialog.js
@@ -47,8 +47,6 @@ export class TSDialog extends TSElement {
 			primary: { type: String, reflect: true },
 			/** If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable` */
 			notification: { type: Boolean, reflect: true },
-			/** Render no buttons. This only affects notifications of type 'success' */
-			noButtons: { type: Boolean, reflect: true, attribute: 'no-buttons' },
 			/** Cannot be dismissed except by clicking available buttons in the dialog/notification */
 			nonDismissable: { type: Boolean, reflect: true, attribute: 'non-dismissable' },
 			/** INTERNAL */
@@ -95,7 +93,7 @@ export class TSDialog extends TSElement {
 
 	updated(changedProps) {
 		super.updated(changedProps);
-		if (changedProps.has('visible') && this.visible === true) {
+		if (this.visible === true) {
 			/** close dismissable success notifications after a timeout */
 			if (this.notification === true && this.type === dialogTypes.SUCCESS && !this.nonDismissable) {
 				return window.setTimeout(() => {
@@ -147,7 +145,7 @@ export class TSDialog extends TSElement {
 	}
 
 	get _hideAllButtons() {
-		return this.noButtons && this.notification && this.type === dialogTypes.SUCCESS;
+		return !this.nonDismissable && this.notification && this.type === dialogTypes.SUCCESS;
 	}
 
 	render() {
@@ -175,8 +173,8 @@ export class TSDialog extends TSElement {
 						>
 							${this.translations.accept_button}
 						</ts-button>
-						<!-- To add more options to the dialog (notifications will ignore extra buttons), between accept and cancel buttons  	-->
 						<div class="${this.notification ? 'visuallyhidden' : ''}">
+							<!-- To add more options to the dialog (notifications will ignore extra buttons), between accept and cancel buttons -->
 							<slot name="extra-buttons" @slotchange="${this.extraButtonsSlotChangeHandler}"></slot>
 						</div>
 						<ts-button

--- a/packages/components/dialog/src/dialog.js
+++ b/packages/components/dialog/src/dialog.js
@@ -49,7 +49,7 @@ export class TSDialog extends TSElement {
 			notification: { type: Boolean, reflect: true },
 			/** Render no buttons. This only affects notifications of type 'success' */
 			noButtons: { type: Boolean, reflect: true, attribute: 'no-buttons' },
-			/** Cannot be dismissed. This only affect notifications */
+			/** Cannot be dismissed except by clicking available buttons in the dialog/notification */
 			nonDismissable: { type: Boolean, reflect: true, attribute: 'non-dismissable' },
 			/** INTERNAL */
 			renderButtons: { type: Boolean, attribute: false }
@@ -114,11 +114,13 @@ export class TSDialog extends TSElement {
 	}
 
 	onCancel() {
-		/**
-		 * Emitted when the user choose the cancel option
-		 */
-		this.dispatchCustomEvent('cancel');
-		this.dismissModal();
+		if (!this.nonDismissable) {
+			/**
+			 * Emitted when the user choose the cancel option
+			 */
+			this.dispatchCustomEvent('cancel');
+			this.dismissModal();
+		}
 	}
 
 	dismissModal() {
@@ -148,18 +150,14 @@ export class TSDialog extends TSElement {
 		return this.noButtons && this.notification && this.type === dialogTypes.SUCCESS;
 	}
 
-	get _nonDismissable() {
-		return this.notification && this.nonDismissable;
-	}
-
 	render() {
 		return html`
 			<ts-modal
 				?data-visible=${this.visible}
 				data-size="small"
 				hide-header
-				?no-close-on-esc-key=${this._nonDismissable}
-				?no-close-on-cover-click=${this._nonDismissable}
+				?no-close-on-esc-key=${this.nonDismissable}
+				?no-close-on-cover-click=${this.nonDismissable}
 			>
 				<div class="content" slot="main">
 					<ts-icon icon="${this.getIcon}" type="${this.getIconType}" size="extra-large"></ts-icon>
@@ -185,7 +183,8 @@ export class TSDialog extends TSElement {
 							?focused="${this.isFocused('cancel')}"
 							@click="${this.onCancel}"
 							type="${this.getCancelButtonType}"
-							class="${this.notification ? 'visuallyhidden' : ''}"
+							class="${this.notification || this.nonDismissable ? 'visuallyhidden' : ''}"
+							?disabled="${this.nonDismissable}"
 						>
 							${this.translations.cancel_button}
 						</ts-button>

--- a/packages/components/dialog/src/utils/constants.js
+++ b/packages/components/dialog/src/utils/constants.js
@@ -1,22 +1,34 @@
 export const dialogTypes = {
+	SUCCESS: 'success',
+	INFO: 'info',
+	ERROR: 'error',
 	CONFIRM: 'confirm',
 	WARNING: 'warning',
 	DANGER: 'danger'
 };
 
 export const dialogTypeIcon = {
+	[dialogTypes.SUCCESS]: 'checkmark',
+	[dialogTypes.INFO]: 'info',
+	[dialogTypes.ERROR]: 'remove',
 	[dialogTypes.CONFIRM]: 'question',
 	[dialogTypes.WARNING]: 'alert',
 	[dialogTypes.DANGER]: 'remove'
 };
 
 export const dialogTypeIconTypes = {
+	[dialogTypes.SUCCESS]: 'success',
+	[dialogTypes.INFO]: 'info',
+	[dialogTypes.ERROR]: 'error',
 	[dialogTypes.CONFIRM]: 'primary',
 	[dialogTypes.WARNING]: 'warning',
 	[dialogTypes.DANGER]: 'danger'
 };
 
 export const dialogTypeButtonType = {
+	[dialogTypes.SUCCESS]: 'accept',
+	[dialogTypes.INFO]: 'primary',
+	[dialogTypes.ERROR]: 'danger',
 	[dialogTypes.CONFIRM]: 'primary',
 	[dialogTypes.WARNING]: 'warning',
 	[dialogTypes.DANGER]: 'danger'

--- a/packages/components/dialog/src/utils/constants.js
+++ b/packages/components/dialog/src/utils/constants.js
@@ -33,3 +33,5 @@ export const dialogTypeButtonType = {
 	[dialogTypes.WARNING]: 'warning',
 	[dialogTypes.DANGER]: 'danger'
 };
+
+export const timeout = 1500;

--- a/packages/components/dialog/src/utils/index.js
+++ b/packages/components/dialog/src/utils/index.js
@@ -1,3 +1,3 @@
-export { dialogTypes, dialogTypeButtonType, dialogTypeIcon, dialogTypeIconTypes } from './constants';
+export { dialogTypes, dialogTypeButtonType, dialogTypeIcon, dialogTypeIconTypes, timeout } from './constants';
 
 export { default as translations } from './translations';

--- a/packages/components/dialog/stories/dialog.happo.js
+++ b/packages/components/dialog/stories/dialog.happo.js
@@ -47,7 +47,6 @@ export const SuccessNotification = () => html`
 		focused="accept"
 		non-dismissable
 		notification
-		no-buttons
 	>
 		<ts-button-group slot="extra-buttons">
 			<ts-button type="danger">another action</ts-button>
@@ -57,7 +56,7 @@ export const SuccessNotification = () => html`
 `;
 
 SuccessNotification.story = {
-	name: 'non-dismissable no-buttons success notification'
+	name: 'non-dismissable success notification'
 };
 
 export const DefaultNotification = () => html`

--- a/packages/components/dialog/stories/dialog.happo.js
+++ b/packages/components/dialog/stories/dialog.happo.js
@@ -7,11 +7,19 @@ export default {
 	title: 'ts-dialog'
 };
 
-export const Test = () => {
+export const DefaultDialog = () => html`
+	<ts-dialog text="Are you sure you want to delete the document?" data-visible type="warning"></ts-dialog>
+`;
+
+DefaultDialog.story = {
+	name: 'warning dialog'
+};
+
+export const ExtraButtonsDialogCustomizedButtons = () => {
 	const translations = { accept_button: 'custom accept', cancel_button: 'custom cancel' };
 	return html`
 		<ts-dialog
-			text="Are you sure you want to delete the document?"
+			text="Warning dialog with extra buttons and customized button wording"
 			data-visible
 			type="warning"
 			primary="cancel"
@@ -24,4 +32,38 @@ export const Test = () => {
 			</ts-button-group>
 		</ts-dialog>
 	`;
+};
+
+ExtraButtonsDialogCustomizedButtons.story = {
+	name: 'extra buttons warning dialog w/ customised buttons'
+};
+
+export const SuccessNotification = () => html`
+	<ts-dialog
+		text="Non-dismissable success notification with no buttons (even though it has buttons in the extra-buttons slot)"
+		data-visible
+		type="success"
+		primary="accept"
+		focused="accept"
+		non-dismissable
+		notification
+		no-buttons
+	>
+		<ts-button-group slot="extra-buttons">
+			<ts-button type="danger">another action</ts-button>
+			<ts-button type="primary">primary action</ts-button>
+		</ts-button-group>
+	</ts-dialog>
+`;
+
+SuccessNotification.story = {
+	name: 'non-dismissable no-buttons success notification'
+};
+
+export const DefaultNotification = () => html`
+	<ts-dialog text="info notification" data-visible type="info" notification></ts-dialog>
+`;
+
+DefaultNotification.story = {
+	name: 'info notification'
 };

--- a/packages/components/dialog/stories/dialog.stories.js
+++ b/packages/components/dialog/stories/dialog.stories.js
@@ -14,7 +14,10 @@ function getKnobs() {
 		focused: select('focused', { accept: 'accept', cancel: 'cancel', null: null }, 'cancel'),
 		primary: select('primary', { accept: 'accept', cancel: 'cancel', null: null }, null),
 		type: select('type', dialogTypes, dialogTypes.CONFIRM),
-		icon: select('icon', Object.keys(icons), Object.keys(icons)[0])
+		icon: select('icon', Object.keys(icons), Object.keys(icons)[0]),
+		notification: boolean('notification', false),
+		nonDismissable: boolean('non-dismissable', false),
+		noButtons: boolean('no-buttons (only success notifications)', false)
 	};
 }
 
@@ -33,6 +36,9 @@ export const Default = () => {
 			focused="${knobs.focused}"
 			type="${knobs.type}"
 			primary="${knobs.primary}"
+			?notification="${knobs.notification}"
+			?no-buttons="${knobs.noButtons}"
+			?non-dismissable="${knobs.nonDismissable}"
 		>
 		</ts-dialog>
 	`;
@@ -54,6 +60,9 @@ export const CustomIcon = () => {
 			icon="${knobs.icon}"
 			type="${knobs.type}"
 			primary="${knobs.primary}"
+			?notification="${knobs.notification}"
+			?no-buttons="${knobs.noButtons}"
+			?non-dismissable="${knobs.nonDismissable}"
 		>
 		</ts-dialog>
 	`;
@@ -61,5 +70,33 @@ export const CustomIcon = () => {
 
 CustomIcon.story = {
 	name: 'custom icon',
+	parameters: { notes: readme }
+};
+
+export const ExtraButtons = () => {
+	const knobs = getKnobs();
+	return html`
+		<ts-dialog
+			?data-visible="${knobs.visible}"
+			translations="${JSON.stringify(knobs.translations)}"
+			text="${knobs.content}"
+			focused="${knobs.focused}"
+			icon="${knobs.icon}"
+			type="${knobs.type}"
+			primary="${knobs.primary}"
+			?notification="${knobs.notification}"
+			?no-buttons="${knobs.noButtons}"
+			?non-dismissable="${knobs.nonDismissable}"
+		>
+			<ts-button-group slot="extra-buttons">
+				<ts-button type="danger">another action</ts-button>
+				<ts-button type="primary">primary action</ts-button>
+			</ts-button-group>
+		</ts-dialog>
+	`;
+};
+
+ExtraButtons.story = {
+	name: 'extra buttons',
 	parameters: { notes: readme }
 };

--- a/packages/components/dialog/stories/dialog.stories.js
+++ b/packages/components/dialog/stories/dialog.stories.js
@@ -16,8 +16,7 @@ function getKnobs() {
 		type: select('type', dialogTypes, dialogTypes.CONFIRM),
 		icon: select('icon', Object.keys(icons), Object.keys(icons)[0]),
 		notification: boolean('notification', false),
-		nonDismissable: boolean('non-dismissable', false),
-		noButtons: boolean('no-buttons (only success notifications)', false)
+		nonDismissable: boolean('non-dismissable', false)
 	};
 }
 
@@ -37,7 +36,6 @@ export const Default = () => {
 			type="${knobs.type}"
 			primary="${knobs.primary}"
 			?notification="${knobs.notification}"
-			?no-buttons="${knobs.noButtons}"
 			?non-dismissable="${knobs.nonDismissable}"
 		>
 		</ts-dialog>
@@ -61,7 +59,6 @@ export const CustomIcon = () => {
 			type="${knobs.type}"
 			primary="${knobs.primary}"
 			?notification="${knobs.notification}"
-			?no-buttons="${knobs.noButtons}"
 			?non-dismissable="${knobs.nonDismissable}"
 		>
 		</ts-dialog>
@@ -85,7 +82,6 @@ export const ExtraButtons = () => {
 			type="${knobs.type}"
 			primary="${knobs.primary}"
 			?notification="${knobs.notification}"
-			?no-buttons="${knobs.noButtons}"
 			?non-dismissable="${knobs.nonDismissable}"
 		>
 			<ts-button-group slot="extra-buttons">

--- a/packages/components/dialog/types/dialog.d.ts
+++ b/packages/components/dialog/types/dialog.d.ts
@@ -1,14 +1,14 @@
 export interface TSDialogHTMLAttributes {
-	/**  Dialog can be toggled by add/removing this attribute  */
+	/**  Dialog can be toggled by adding/removing this attribute  */
 	"data-visible"?: boolean;
 
 	/**  Text content of the modal  */
 	text?: string;
 
-	/**  If you need a different icon that default ones, you can use one of Elements icon names  */
+	/**  If you need a different icon that default ones, you can use one of Elements icon names. Notifications will ignore this  */
 	icon?: string;
 
-	/**  `confirm`, `warning`, `danger`  */
+	/**  `success`, `info`, `confirm`, `warning`, `danger`, `error`  */
 	type?: string;
 
 	/**  can be used for customizing the buttons text and translations  */
@@ -20,19 +20,28 @@ export interface TSDialogHTMLAttributes {
 	/**  either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary  */
 	primary?: string;
 
+	/**  If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable`  */
+	notification?: boolean;
+
+	/**  Render no buttons. This only affects notifications of type 'success'  */
+	"no-buttons"?: boolean;
+
+	/**  Cannot be dismissed. This only affect notifications  */
+	"non-dismissable"?: boolean;
+
 }
 
 export interface TSDialog {
-	/**  Dialog can be toggled by add/removing this attribute  */
+	/**  Dialog can be toggled by adding/removing this attribute  */
 	visible?: boolean;
 
 	/**  Text content of the modal  */
 	text?: string;
 
-	/**  If you need a different icon that default ones, you can use one of Elements icon names  */
+	/**  If you need a different icon that default ones, you can use one of Elements icon names. Notifications will ignore this  */
 	icon?: string;
 
-	/**  `confirm`, `warning`, `danger`  */
+	/**  `success`, `info`, `confirm`, `warning`, `danger`, `error`  */
 	type?: string;
 
 	/**  can be used for customizing the buttons text and translations  */
@@ -43,5 +52,14 @@ export interface TSDialog {
 
 	/**  either `accept` or `cancel` can be used to change the button type, based on the dialog type, by default both are secondary  */
 	primary?: string;
+
+	/**  If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable`  */
+	notification?: boolean;
+
+	/**  Render no buttons. This only affects notifications of type 'success'  */
+	noButtons?: boolean;
+
+	/**  Cannot be dismissed. This only affect notifications  */
+	nonDismissable?: boolean;
 
 }

--- a/packages/components/dialog/types/dialog.d.ts
+++ b/packages/components/dialog/types/dialog.d.ts
@@ -23,9 +23,6 @@ export interface TSDialogHTMLAttributes {
 	/**  If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable`  */
 	notification?: boolean;
 
-	/**  Render no buttons. This only affects notifications of type 'success'  */
-	"no-buttons"?: boolean;
-
 	/**  Cannot be dismissed except by clicking available buttons in the dialog/notification  */
 	"non-dismissable"?: boolean;
 
@@ -55,9 +52,6 @@ export interface TSDialog {
 
 	/**  If it is a notification, no cancel button will be rendered. Notifications of type 'success' will auto-close on timeout, if they are not `non-dismissable`  */
 	notification?: boolean;
-
-	/**  Render no buttons. This only affects notifications of type 'success'  */
-	noButtons?: boolean;
 
 	/**  Cannot be dismissed except by clicking available buttons in the dialog/notification  */
 	nonDismissable?: boolean;

--- a/packages/components/dialog/types/dialog.d.ts
+++ b/packages/components/dialog/types/dialog.d.ts
@@ -26,7 +26,7 @@ export interface TSDialogHTMLAttributes {
 	/**  Render no buttons. This only affects notifications of type 'success'  */
 	"no-buttons"?: boolean;
 
-	/**  Cannot be dismissed. This only affect notifications  */
+	/**  Cannot be dismissed except by clicking available buttons in the dialog/notification  */
 	"non-dismissable"?: boolean;
 
 }
@@ -59,7 +59,7 @@ export interface TSDialog {
 	/**  Render no buttons. This only affects notifications of type 'success'  */
 	noButtons?: boolean;
 
-	/**  Cannot be dismissed. This only affect notifications  */
+	/**  Cannot be dismissed except by clicking available buttons in the dialog/notification  */
 	nonDismissable?: boolean;
 
 }

--- a/packages/components/modal/README.md
+++ b/packages/components/modal/README.md
@@ -37,6 +37,7 @@
 | title | data-title | String | '' | Modal header text |
 | visible | data-visible | Boolean | false | Show/hide the modal |
 | noCloseOnEscKey | no-close-on-esc-key | Boolean | false | Disable the functionality to close the modal on press of escape key |
+| noCloseOnCoverClick | no-close-on-cover-click | Boolean | false | Disable the functionality to close the modal by clicking the cover (background) |
 | hideHeader | hide-header | Boolean | false | Show/hide the title of the modal |
 | noPadding | no-padding | Boolean | false | Add/remove standard paddings to the main content |
 

--- a/packages/components/modal/src/modal.js
+++ b/packages/components/modal/src/modal.js
@@ -17,6 +17,7 @@ export class TSModal extends TSElement {
 		this.closeBehavior = new CloseOnEscBehavior(this);
 		this.hideHeader = false;
 		this.noPadding = false;
+		this.noCloseOnCoverClick = false;
 	}
 
 	static get styles() {
@@ -35,6 +36,8 @@ export class TSModal extends TSElement {
 			visible: { type: Boolean, reflect: true, attribute: 'data-visible' },
 			/** Disable the functionality to close the modal on press of escape key */
 			noCloseOnEscKey: { type: Boolean, attribute: 'no-close-on-esc-key' },
+			/** Disable the functionality to close the modal by clicking the cover (background) */
+			noCloseOnCoverClick: { type: Boolean, attribute: 'no-close-on-cover-click' },
 			/** Show/hide the title of the modal */
 			hideHeader: { type: Boolean, attribute: 'hide-header' },
 			/** Add/remove standard paddings to the main content */
@@ -66,11 +69,13 @@ export class TSModal extends TSElement {
 	}
 
 	close() {
-		this.visible = false;
-		/**
-		 * Emitted on start of the modal closing
-		 */
-		this.dispatchCustomEvent('close');
+		if (!this.noCloseOnCoverClick) {
+			this.visible = false;
+			/**
+			 * Emitted on start of the modal closing
+			 */
+			this.dispatchCustomEvent('close');
+		}
 	}
 
 	handleTransition(e) {

--- a/packages/components/modal/types/modal.d.ts
+++ b/packages/components/modal/types/modal.d.ts
@@ -14,6 +14,9 @@ export interface TSModalHTMLAttributes {
 	/**  Disable the functionality to close the modal on press of escape key  */
 	"no-close-on-esc-key"?: boolean;
 
+	/**  Disable the functionality to close the modal by clicking the cover (background)  */
+	"no-close-on-cover-click"?: boolean;
+
 	/**  Show/hide the title of the modal  */
 	"hide-header"?: boolean;
 
@@ -37,6 +40,9 @@ export interface TSModal {
 
 	/**  Disable the functionality to close the modal on press of escape key  */
 	noCloseOnEscKey?: boolean;
+
+	/**  Disable the functionality to close the modal by clicking the cover (background)  */
+	noCloseOnCoverClick?: boolean;
 
 	/**  Show/hide the title of the modal  */
 	hideHeader?: boolean;

--- a/packages/core/src/utils/constants.js
+++ b/packages/core/src/utils/constants.js
@@ -33,8 +33,7 @@ export const colors = {
 export const delay = {
 	NOW: 100,
 	FAST: 200,
-	SLOW: 600,
-	CLOSE: 1500
+	SLOW: 600
 };
 
 export const keyboardEventKeys = {

--- a/packages/core/src/utils/constants.js
+++ b/packages/core/src/utils/constants.js
@@ -33,7 +33,8 @@ export const colors = {
 export const delay = {
 	NOW: 100,
 	FAST: 200,
-	SLOW: 600
+	SLOW: 600,
+	CLOSE: 1500
 };
 
 export const keyboardEventKeys = {


### PR DESCRIPTION
Task: https://tradeshift.atlassian.net/browse/PEAA-395

These changes add notification features to the dialog element:

A dialog can have a `notification` attribute and will have no cancel button, and if `no-buttons`, no buttons at all.

A `success` type `notification` will auto-close after 1500 ms, if not non-dismissable.

A `non-dismissable` notification or dialog cannot be closed except by clicking a button provided by the dialog/notification.

The changes also include a fix that makes auto-focusing a button ('accept' or 'cancel') work, although only in dialog (not notification) mode, and a new attribute is added to ts-modal, making closing on clicking the cover optional.