### PR TITLE
fix(button): fixes missing/broken focus state styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
 					<a href="/packages/components/board/index.html">Board</a>
 				</li>
 				<li>
+					<a href="/packages/components/button/index.html">Button</a>
+				</li>
+				<li>
 					<a href="/packages/components/button-group/index.html">Button-Group</a>
 				</li>
 				<li>

--- a/packages/components/button/index.html
+++ b/packages/components/button/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Tradeshift Elements - button</title>
+
+		<!-- Don't shim CSS Custom Properties on IE11 -->
+		<script>
+			if (!window.Promise) {
+				window.ShadyCSS = { nativeCss: true };
+			}
+		</script>
+
+		<!-- Enable ES5 class-less Custom Elements -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+		<!-- Load appropriate polyfills and shims -->
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+
+		<!-- Set :root CSS Custom Properties -->
+		<link rel="stylesheet" href="/packages/core/src/vars.css" />
+		<!-- Set @font-face for all needed fonts -->
+		<link rel="stylesheet" href="/packages/core/src/fonts.css" />
+		<!-- Set margin/padding to be 0 for <html> -->
+		<link rel="stylesheet" href="/packages/core/src/reset.css" />
+
+		<!-- Load user-styles -->
+		<link rel="stylesheet" href="/index.css" />
+
+		<script type="module" src="/packages/components/button/lib/button.esm.js"></script>
+		<script type="module" src="/packages/components/board/lib/board.esm.js"></script>
+	</head>
+
+	<body>
+		<article>
+			<ts-board data-title="ts-button">
+				<ts-button slot="header-actions">Default/macro size button</ts-button>
+				<ts-button type="secondary">secondary</ts-button>
+				<ts-button type="primary">primary</ts-button>
+				<ts-button type="accept">accept</ts-button>
+				<ts-button type="warning">warning</ts-button>
+				<ts-button type="danger">danger</ts-button>
+				<ts-button type="text">text</ts-button>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-button, micro">
+				<ts-button slot="header-actions" size="micro">Micro button</ts-button>
+				<ts-button size="micro" type="secondary">secondary</ts-button>
+				<ts-button size="micro" type="primary">primary</ts-button>
+				<ts-button size="micro" type="accept">accept</ts-button>
+				<ts-button size="micro" type="warning">warning</ts-button>
+				<ts-button size="micro" type="danger">danger</ts-button>
+				<ts-button size="micro" type="text">text</ts-button>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-button, icon">
+				<ts-button icon="info" type="secondary">secondary</ts-button>
+				<ts-button icon="info" type="primary">primary</ts-button>
+				<ts-button icon="info" type="accept">accept</ts-button>
+				<ts-button icon="info" type="warning">warning</ts-button>
+				<ts-button icon="info" type="danger">danger</ts-button>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-button, no-border">
+				<ts-button slot="header-actions" class="no-border" size="micro">no-border button</ts-button>
+				<ts-button icon="info" type="secondary" class="no-border">action</ts-button>
+			</ts-board>
+		</article>
+		<article>
+			<ts-board data-title="ts-button, action">
+				<ts-button icon="info" type="text">action</ts-button>
+			</ts-board>
+		</article>
+	</body>
+</html>

--- a/packages/components/button/src/button.css
+++ b/packages/components/button/src/button.css
@@ -1,11 +1,13 @@
 /* General........................................................ */
 
 :host {
+	--ts-box-shadow-color: transparent;
 	display: inline-block;
 	font-size: var(--ts-font-size-default);
 	line-height: var(--ts-unit);
 
 	& > button {
+		box-shadow: var(--ts-boxshadow-focus-border) var(--ts-box-shadow-color);
 		position: relative;
 		min-width: var(--ts-unit-double);
 		border: none;
@@ -19,7 +21,6 @@
 		padding: var(--ts-unit-half) var(--ts-unit);
 		font-weight: var(--ts-fontweight-semibold);
 		text-transform: uppercase;
-		letter-spacing: 0.02em;
 		line-height: var(--ts-unit);
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
@@ -43,7 +44,7 @@
 		box-shadow: var(--ts-boxshadow-border-default);
 
 		&:focus {
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
+			box-shadow: var(--ts-boxshadow-focus-border) var(--ts-color-blue);
 		}
 	}
 }
@@ -74,7 +75,7 @@
 		}
 
 		&:focus {
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue-darker);
+			--ts-box-shadow-color: var(--ts-color-blue-darker);
 		}
 	}
 }
@@ -95,7 +96,7 @@
 		}
 
 		&:focus {
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-green-darker);
+			--ts-box-shadow-color: var(--ts-color-green-darker);
 		}
 	}
 }
@@ -116,7 +117,7 @@
 		}
 
 		&:focus {
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-orange-darker);
+			--ts-box-shadow-color: var(--ts-color-orange-darker);
 		}
 	}
 }
@@ -137,7 +138,7 @@
 		}
 
 		&:focus {
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-red-darker);
+			--ts-box-shadow-color: var(--ts-color-red-darker);
 		}
 	}
 }
@@ -203,7 +204,7 @@
 
 		&:focus {
 			background: var(--ts-color-gray-lightest);
-			box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-gray);
+			--ts-box-shadow-color: var(--ts-color-gray);
 			& span {
 				color: var(--ts-color-blue-darkest);
 			}

--- a/packages/components/radio-group/src/radio-group.css
+++ b/packages/components/radio-group/src/radio-group.css
@@ -20,12 +20,12 @@
 	}
 
 	& .frame:hover {
-		box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue-light);
+		box-shadow: var(--ts-boxshadow-border-width) var(--ts-color-blue-light);
 	}
 }
 
 :host([focused]) {
 	& .frame {
-		box-shadow: var(--ts-boxshadow-border-width-focused) var(--ts-color-blue);
+		box-shadow: var(--ts-boxshadow-border-width) var(--ts-color-blue);
 	}
 }

--- a/packages/core/src/vars.css
+++ b/packages/core/src/vars.css
@@ -134,6 +134,7 @@
 	/* Borders........................................................ */
 
 	--ts-border-width: 1px;
+	--ts-focus-border-width: 2px;
 	--ts-border-type: solid;
 	--ts-border-color-default: var(--ts-color-gray-light);
 	--ts-border-color-error: var(--ts-color-red);
@@ -149,6 +150,7 @@
 	--ts-border-focus: var(--ts-border-width) var(--ts-border-type) var(--ts-border-color-focus);
 	--ts-border-disabled: var(--ts-border-width) var(--ts-border-type) var(--ts-border-color-disabled);
 	--ts-boxshadow-border-width: inset 0 0 0 var(--ts-border-width);
+	--ts-boxshadow-focus-border: inset 0 0 0 var(--ts-focus-border-width);
 	--ts-boxshadow-border-default: var(--ts-boxshadow-border-width) var(--ts-border-color-default);
 	--ts-boxshadow-border-error: var(--ts-boxshadow-border-width) var(--ts-border-color-error);
 	--ts-boxshadow-border-success: var(--ts-boxshadow-border-width) var(--ts-border-color-success);


### PR DESCRIPTION
Motivation: ts-buttons are lacking a border indicating focused state. In case type=secondary it makes a focused button look like plain text.

Note that letter-spacing is removed on the buttons, because there is no custom letter-spacing in the design. It improves readability IMO, but triggers a lot of happo snapshot changes.

Design: https://www.figma.com/file/v4lzSShpqzYtQ5aQRcKAmV/UI-Library---Clean-(New-system-without-documentation)?node-id=3453%3A1