### PR TITLE
chore(deps): disable dependency-auto-update.yml cron job

### DIFF
--- a/.github/workflows/dependency-auto-update.yml
+++ b/.github/workflows/dependency-auto-update.yml
@@ -1,8 +1,8 @@
 # .github/workflows/dependency-auto-update.yml
 name: Dependency tree auto-update
 on:
-  schedule:
-    - cron:  '0 11 * * 1,4' # Frequency of your preference, this one runs Mondays and Thursdays at 11am
+#  schedule:
+#    - cron:  '0 11 * * 1,4' # Frequency of your preference, this one runs Mondays and Thursdays at 11am
   workflow_dispatch: # Allow running manually
 jobs:
   update:


### PR DESCRIPTION
Since we are using Happo for visual regression testing on each PR update,
we are using our snapshots quota on these PRs, which are pretty limited.
I'm disabling it, until we either increase the quota or replace Happo
with another solution.