### PR TITLE
chore(deps): temporarily disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    rebase-strategy: "auto"
+    rebase-strategy: "disabled"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Since we are using Happo for visual regression testing on each PR update,
we are using our snapshots quota on these PRs, which are pretty limited.
I'm disabling it, until we either increase the quota or replace Happo
with another solution.