### PR TITLE
Add a happo story with all available icons

### DIFF
--- a/packages/components/board/stories/board.happo.js
+++ b/packages/components/board/stories/board.happo.js
@@ -38,7 +38,7 @@ export const Board2 = () => {
 			<div slot="header-actions" style="display: flex; align-items:center;">
 				<ts-button size="macro">Some button </ts-button>
 				<ts-button size="micro" type="danger">click</ts-button>
-				<ts-action-select items="${items}"></ts-action-select>
+				<ts-action-select .items="${items}"></ts-action-select>
 			</div>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam earum hic iusto minus nostrum, similique

--- a/packages/components/button/src/button.js
+++ b/packages/components/button/src/button.js
@@ -53,12 +53,14 @@ export class TSButton extends TSElement {
 		return colorBackgroundTypes.indexOf(this.type) > -1 ? 'inverted' : 'default';
 	}
 
-	attributeChangedCallback(name, oldVal, newVal) {
-		super.attributeChangedCallback(name, oldVal, newVal);
-		if (name === 'focused' && this.focused) {
-			// set focus only when component is defined.
-			window.customElements.whenDefined('ts-button').then(() => this.shadowRoot.getElementById('button').focus());
-		}
+	updated(changedProperties) {
+		changedProperties.forEach((oldValue, propName) => {
+			if (propName === 'focused') {
+				if (!oldValue) {
+					window.customElements.whenDefined('ts-button').then(() => this.shadowRoot.getElementById('button').focus());
+				}
+			}
+		});
 	}
 
 	clickHandler(event) {

--- a/packages/components/icon/stories/icon.happo.js
+++ b/packages/components/icon/stories/icon.happo.js
@@ -1,8 +1,12 @@
+import { html } from 'lit-html';
 import '@tradeshift/elements';
+// eslint-disable-next-line import/no-duplicates
 import '@tradeshift/elements.icon';
 
 import { createHappoStories } from '../../../../.storybook-happo/utils';
 import { types, sizes } from '../src/utils';
+// eslint-disable-next-line import/no-duplicates
+import { icons } from '@tradeshift/elements.icon';
 
 export default {
 	title: 'ts-icon'
@@ -34,4 +38,25 @@ export const Test = () => {
 	};
 
 	return createHappoStories('icon', properties, '', options);
+};
+
+export const TestAllIcons = () => {
+	return html`
+		<style>
+			.render-block {
+				flex: 0 0 var(--ts-unit-triple);
+			}
+		</style>
+		<div style="display: flex; flex-flow: row wrap; gap: 1rem;">
+			${Object.keys(icons).map(
+				icon =>
+					html`<ts-icon
+						class="render-block"
+						type="${types.PRIMARY}"
+						icon="${icon}"
+						size="${sizes.EXTRA_LARGE}"
+					></ts-icon>`
+			)}
+		</div>
+	`;
 };

--- a/packages/components/radio/stories/radio.happo.js
+++ b/packages/components/radio/stories/radio.happo.js
@@ -3,7 +3,7 @@ import '@tradeshift/elements';
 import '@tradeshift/elements.radio-group';
 
 export default {
-	title: 'ts-radio-group'
+	title: 'ts-radio-in-radio-group'
 };
 
 export const Test = () => {


### PR DESCRIPTION
Added a story with all available icons for `ts-icon` component. Some icons looks strange, it will be fixed in following PRs.
![image](https://user-images.githubusercontent.com/55530374/161578476-b219dcd1-223d-4a29-9727-e0dad260d1cf.png)
