### PR TITLE
Add install scripts to a new version script to avoid unexpected changes in package-lock

### DIFF
--- a/scripts/new-version.sh
+++ b/scripts/new-version.sh
@@ -13,6 +13,10 @@ else
 	branch="release/$version"
 	git checkout -b $branch
 
+	# run install scripts to avoid unexpected changes in package-lock.json
+	npm ci
+	npm run lerna:bootstrap:ci
+
 	# commit a changelog and a new version
 	git add .
 	git commit -m "chore(release): $version"


### PR DESCRIPTION
Run the same install scripts that we have in release GHA, so it should solve the issue with unexpected changes in package-lock.json