### PR TITLE
Fix storybook deploy

### DIFF
--- a/.storybook-happo/preview-head.html
+++ b/.storybook-happo/preview-head.html
@@ -31,5 +31,5 @@
 	})();
 </script>
 
-<link rel="stylesheet" href="../packages/core/src/fonts.css" />
-<link rel="stylesheet" href="../packages/core/src/vars.css" />
+<link rel="stylesheet" href="packages/core/src/fonts.css" />
+<link rel="stylesheet" href="packages/core/src/vars.css" />

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -31,5 +31,5 @@
 	})();
 </script>
 
-<link rel="stylesheet" href="../packages/core/src/fonts.css" />
-<link rel="stylesheet" href="../packages/core/src/vars.css" />
+<link rel="stylesheet" href="packages/core/src/fonts.css" />
+<link rel="stylesheet" href="packages/core/src/vars.css" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -7655,22 +7655,6 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
-    "node_modules/@storybook/addon-notes/node_modules/hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "dev": true,
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/@storybook/addon-notes/node_modules/isobject": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
@@ -7678,30 +7662,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/addon-notes/node_modules/lowlight": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
-      "dev": true,
-      "dependencies": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
-      }
-    },
-    "node_modules/@storybook/addon-notes/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dev": true,
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
       }
     },
     "node_modules/@storybook/addon-notes/node_modules/polished": {
@@ -7714,37 +7674,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/addon-notes/node_modules/react-syntax-highlighter": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
-      "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.18.2",
-        "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.4.1"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/@storybook/addon-notes/node_modules/refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-      "dev": true,
-      "dependencies": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@storybook/addon-notes/node_modules/telejson": {
@@ -19749,15 +19678,6 @@
         "upper-case": "^1.1.3"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
-      "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -22632,6 +22552,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/lru-cache": {
@@ -28151,6 +28080,15 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-syntax-highlighter/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/react-textarea-autosize": {
@@ -40156,7 +40094,7 @@
             "react-focus-lock": "^2.1.0",
             "react-helmet-async": "^1.0.2",
             "react-popper-tooltip": "^2.8.3",
-            "react-syntax-highlighter": "^11.0.2",
+            "react-syntax-highlighter": ">=15.5.0",
             "react-textarea-autosize": "^7.1.0",
             "simplebar-react": "^1.0.0-alpha.6",
             "ts-dedent": "^1.1.0"
@@ -40215,47 +40153,11 @@
           "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
           "dev": true
         },
-        "hastscript": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-          "dev": true,
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "hast-util-parse-selector": "^2.0.0",
-            "property-information": "^5.0.0",
-            "space-separated-tokens": "^1.0.0"
-          }
-        },
         "isobject": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
           "dev": true
-        },
-        "lowlight": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-          "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
-          "dev": true,
-          "requires": {
-            "fault": "^1.0.2",
-            "highlight.js": ">=10.4.1"
-          }
-        },
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "dev": true,
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
         },
         "polished": {
           "version": "3.7.2",
@@ -40264,30 +40166,6 @@
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.12.5"
-          }
-        },
-        "react-syntax-highlighter": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
-          "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "highlight.js": ">=10.4.1",
-            "lowlight": "~1.11.0",
-            "prismjs": ">=1.25.0",
-            "refractor": "^2.4.1"
-          }
-        },
-        "refractor": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-          "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-          "dev": true,
-          "requires": {
-            "hastscript": "^5.0.0",
-            "parse-entities": "^1.1.2",
-            "prismjs": ">=1.25.0"
           }
         },
         "telejson": {
@@ -49755,12 +49633,6 @@
         "upper-case": "^1.1.3"
       }
     },
-    "highlight.js": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
-      "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -51968,7 +51840,15 @@
       "dev": true,
       "requires": {
         "fault": "^1.0.0",
-        "highlight.js": ">=10.4.1"
+        "highlight.js": "~10.7.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.7.3",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+          "dev": true
+        }
       }
     },
     "lru-cache": {
@@ -56114,10 +55994,18 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": ">=10.4.1",
+        "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
         "prismjs": ">=1.25.0",
         "refractor": "^3.6.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.7.3",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+          "dev": true
+        }
       }
     },
     "react-textarea-autosize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15463,16 +15463,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/default-browser-id/node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -28488,6 +28478,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerate": {
@@ -46176,7 +46175,7 @@
             "object-assign": "^4.0.1",
             "read-pkg-up": "^1.0.1",
             "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "trim-newlines": "^3.0.1"
           }
         },
         "normalize-package-data": {
@@ -46291,13 +46290,6 @@
           "requires": {
             "get-stdin": "^4.0.1"
           }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -52215,7 +52207,7 @@
         "normalize-package-data": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
+        "trim-newlines": "^3.0.1",
         "type-fest": "^0.18.0",
         "yargs-parser": "^20.2.3"
       },
@@ -55996,7 +55988,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
-        "prismjs": ">=1.25.0",
+        "prismjs": "^1.27.0",
         "refractor": "^3.6.0"
       },
       "dependencies": {
@@ -56321,7 +56313,15 @@
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": ">=1.25.0"
+        "prismjs": "~1.27.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+          "dev": true
+        }
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,9 @@
     "access": "public"
   },
   "overrides": {
-    "highlight.js": ">=10.4.1",
+    "@storybook/addon-notes@5.3.21": {
+      "react-syntax-highlighter": ">=15.5.0"
+    },
     "glob-parent": ">=5.1.2",
     "nth-check": ">=2.0.1",
     "prismjs": ">=1.25.0",

--- a/package.json
+++ b/package.json
@@ -138,9 +138,9 @@
     "@storybook/addon-notes@5.3.21": {
       "react-syntax-highlighter": ">=15.5.0"
     },
+    "trim-newlines": "^3.0.1",
     "glob-parent": ">=5.1.2",
     "nth-check": ">=2.0.1",
-    "prismjs": ">=1.25.0",
     "trim": ">=0.0.3"
   },
   "storybook-deployer": {


### PR DESCRIPTION
After we introduced npm overrides storybook has stop building successfully due to some inconsistency in dependencies.
I added the override for `react-syntax-highlighter` for no longer supported storybook addon `@storybook/addon-notes@5.3.21` to align with other storybook plugins and it seems to solve the issue.
Also, added an override for `trim-newlines` package to address the dependabot alert.