### PR TITLE
fix: make html attrs to be string or boolean. Support "class" attr instead of "className"

### DIFF
--- a/packages/components/action-select/types/action-select.d.ts
+++ b/packages/components/action-select/types/action-select.d.ts
@@ -1,4 +1,6 @@
 export interface TSActionSelectHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
@@ -9,7 +11,7 @@ export interface TSActionSelectHTMLAttributes {
 	opened?: boolean;
 
 	/**  Array of action items. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
-	items?: any[];
+	items?: string;
 
 }
 

--- a/packages/components/app-icon/types/app-icon.d.ts
+++ b/packages/components/app-icon/types/app-icon.d.ts
@@ -1,4 +1,6 @@
 export interface TSAppIconHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Size of the app icon, available variants: ''(default), 'large'  */
 	size?: string;
 

--- a/packages/components/aside/types/aside.d.ts
+++ b/packages/components/aside/types/aside.d.ts
@@ -1,4 +1,6 @@
 export interface TSAsideHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'  */
 	dir?: string;
 

--- a/packages/components/basic-table/types/basic-table.d.ts
+++ b/packages/components/basic-table/types/basic-table.d.ts
@@ -1,15 +1,17 @@
 export interface TSBasicTableHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'  */
 	dir?: string;
 
 	/**  <br> List of columns configs, including: <br> - property: Property key of the column in data object, <br> - value: value of the title of column', <br> - visibility?: Which screen sizes this column should be visible -> 'always-visible'(default) or 'desktop-only' or 'mobile-only', <br> - size?: 'small' or 'medium' or 'large', <br> - display?: 'left' or 'right' or 'center', <br> - renderer?: you can pass a renderer function to customize the content of the cells in this column, args: (cellValue, rowObject) <br>  */
-	cols?: any[];
+	cols?: string;
 
 	/**  List of selected rows ids (caveat: the row should include id property)   */
-	selectedIds?: any[];
+	selectedIds?: string;
 
 	/**  List of rows data objects  */
-	data?: any[];
+	data?: string;
 
 }
 

--- a/packages/components/board/types/board.d.ts
+++ b/packages/components/board/types/board.d.ts
@@ -1,4 +1,6 @@
 export interface TSBoardHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'  */
 	dir?: string;
 

--- a/packages/components/button-group/types/button-group.d.ts
+++ b/packages/components/button-group/types/button-group.d.ts
@@ -1,4 +1,6 @@
 export interface TSButtonGroupHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'  */
 	dir?: string;
 

--- a/packages/components/button/types/button.d.ts
+++ b/packages/components/button/types/button.d.ts
@@ -1,4 +1,6 @@
 export interface TSButtonHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Button type to have different style `primary`, `secondary`, `text`, `accept`, `warning`, `danger`  */
 	type?: string;
 

--- a/packages/components/card/types/card.d.ts
+++ b/packages/components/card/types/card.d.ts
@@ -1,4 +1,6 @@
 export interface TSCardHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	type?: string;
 
 	orientation?: string;

--- a/packages/components/checkbox/types/checkbox.d.ts
+++ b/packages/components/checkbox/types/checkbox.d.ts
@@ -1,4 +1,6 @@
 export interface TSCheckboxHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Name of checkbox  */
 	name?: string;
 

--- a/packages/components/confirmation-prompt/types/confirmation-prompt.d.ts
+++ b/packages/components/confirmation-prompt/types/confirmation-prompt.d.ts
@@ -1,4 +1,6 @@
 export interface TSConfirmationPromptHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Dialog can be toggled by add/removing this attribute  */
 	"data-visible"?: boolean;
 
@@ -18,13 +20,13 @@ export interface TSConfirmationPromptHTMLAttributes {
 	"text-field-placeholder"?: string;
 
 	/**  Array of messages to pass to help-text component. See help-text component for more info   */
-	"help-text-messages"?: any[];
+	"help-text-messages"?: string;
 
 	/**  If you have more than one help text message, you should pass a title to it. See help-text component for more info   */
 	"help-text-title"?: string;
 
 	/**  Can be used for customizing the buttons text and providing translations for them  */
-	translations?: object;
+	translations?: string;
 
 	/**  Text that the user need to type for confirmation   */
 	"text-to-match"?: string;

--- a/packages/components/cover/types/cover.d.ts
+++ b/packages/components/cover/types/cover.d.ts
@@ -1,4 +1,6 @@
 export interface TSCoverHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	"data-visible"?: boolean;
 
 }

--- a/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
+++ b/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
@@ -1,9 +1,11 @@
 export interface TSDatePickerOverlayHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	dir?: string;
 
-	translations?: object;
+	translations?: string;
 
-	firstDay?: number;
+	firstDay?: string;
 
 	pageDate?: string;
 
@@ -11,7 +13,7 @@ export interface TSDatePickerOverlayHTMLAttributes {
 
 	required?: boolean;
 
-	disabledDateCheck?: function;
+	disabledDateCheck?: string;
 
 }
 

--- a/packages/components/date-picker/types/date-picker.d.ts
+++ b/packages/components/date-picker/types/date-picker.d.ts
@@ -1,6 +1,8 @@
 export interface TSDatePickerHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Can be used for customizing placeholder, days abbreviations, months abbreviations and providing translations for them <br> see the structure in its storybook knobs section. <br>  */
-	translations?: object;
+	translations?: string;
 
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
@@ -21,7 +23,7 @@ export interface TSDatePickerHTMLAttributes {
 	readonly?: boolean;
 
 	/**  You can pass a function to this prop, which will get js Date object of the days in the calendar view as input, <br>  and expect a boolean to make the day disabled or not.  */
-	isDisabledDate?: function;
+	isDisabledDate?: string;
 
 	/**  Minimum date which can be selected by the user. Dates before this will be shown as disabled. Supports ISO 8601 format  */
 	min?: string;
@@ -36,10 +38,10 @@ export interface TSDatePickerHTMLAttributes {
 	"not-typeable"?: boolean;
 
 	/**  Which day should be shown as the first day of the week. A number between 0-6 (0 = Sunday, 6 = Saturday)  */
-	"first-day"?: number;
+	"first-day"?: string;
 
 	/**  Array of messages to pass to help-text component. See help-text component for more info  */
-	"help-text-messages"?: any[];
+	"help-text-messages"?: string;
 
 	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info  */
 	"help-text-title"?: string;
@@ -48,7 +50,7 @@ export interface TSDatePickerHTMLAttributes {
 	"help-text-type"?: string;
 
 	/**  Error messages to show underneath of the input when it has error  */
-	"error-messages"?: any[];
+	"error-messages"?: string;
 
 	/**  Error title, if there are more than one error message  */
 	"error-title"?: string;

--- a/packages/components/dialog/types/dialog.d.ts
+++ b/packages/components/dialog/types/dialog.d.ts
@@ -1,4 +1,6 @@
 export interface TSDialogHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Dialog can be toggled by adding/removing this attribute  */
 	"data-visible"?: boolean;
 
@@ -12,7 +14,7 @@ export interface TSDialogHTMLAttributes {
 	type?: string;
 
 	/**  can be used for customizing the buttons text and translations  */
-	translations?: object;
+	translations?: string;
 
 	/**  set the default focus on the button, either `accept` or `cancel`  */
 	focused?: string;

--- a/packages/components/document-card/types/document-card.d.ts
+++ b/packages/components/document-card/types/document-card.d.ts
@@ -1,4 +1,6 @@
 export interface TSDocumentCardHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	dir?: string;
 
 	name?: string;

--- a/packages/components/file-card/types/file-card.d.ts
+++ b/packages/components/file-card/types/file-card.d.ts
@@ -1,9 +1,11 @@
 export interface TSFileCardHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  type/state of the file card: 'download', 'failed', 'uploading'  */
 	state?: string;
 
 	/**  File data object, {name, size, ...}  */
-	"file-object"?: object;
+	"file-object"?: string;
 
 	rtl?: boolean;
 

--- a/packages/components/file-size/types/file-size.d.ts
+++ b/packages/components/file-size/types/file-size.d.ts
@@ -1,9 +1,11 @@
 export interface TSFileSizeHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Size of the file  */
-	size?: number;
+	size?: string;
 
 	/**  How many decimal points should be shown  */
-	"decimal-point"?: number;
+	"decimal-point"?: string;
 
 	/**  Typography variant  */
 	variant?: string;

--- a/packages/components/file-uploader-input/types/file-uploader-input.d.ts
+++ b/packages/components/file-uploader-input/types/file-uploader-input.d.ts
@@ -1,4 +1,6 @@
 export interface TSFileUploaderInputHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	rtl?: boolean;
 
 	/**  Disable the input  */
@@ -11,14 +13,14 @@ export interface TSFileUploaderInputHTMLAttributes {
 	size?: string;
 
 	/**  List of accepted file extensions  */
-	"accepted-file-extensions"?: any[];
+	"accepted-file-extensions"?: string;
 
 	/**  Disable drag and drop functionality  */
 	"disable-drag-and-drop"?: boolean;
 
 	"help-text-title"?: string;
 
-	"help-text-messages"?: any[];
+	"help-text-messages"?: string;
 
 	/**  Hide the help text about allowed file types.  */
 	"hide-file-type-help-text"?: boolean;
@@ -27,7 +29,7 @@ export interface TSFileUploaderInputHTMLAttributes {
 	"hide-max-file-number-help-text"?: boolean;
 
 	/**  Maximum limit for number of files to be shown as helper message  */
-	"max-file-number"?: number;
+	"max-file-number"?: string;
 
 }
 

--- a/packages/components/header/types/header.d.ts
+++ b/packages/components/header/types/header.d.ts
@@ -1,4 +1,6 @@
 export interface TSHeaderHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the button `rtl`, `ltr`  */
 	dir?: string;
 

--- a/packages/components/help-text/types/help-text.d.ts
+++ b/packages/components/help-text/types/help-text.d.ts
@@ -1,6 +1,8 @@
 export interface TSHelpTextHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  List of message(s)  */
-	messages?: any[];
+	messages?: string;
 
 	/**  If there are multiple messages, there should be a title for the help text  */
 	title?: string;

--- a/packages/components/icon/types/icon.d.ts
+++ b/packages/components/icon/types/icon.d.ts
@@ -1,4 +1,6 @@
 export interface TSIconHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Icon name, ex: 'arrow-up' or inline svg string  */
 	icon?: string;
 
@@ -15,7 +17,7 @@ export interface TSIconHTMLAttributes {
 	circular?: boolean;
 
 	/**  90, 180, 270  */
-	rotate?: number;
+	rotate?: string;
 
 	/**  'h', 'horizontal', 'v', 'vertical'  */
 	flip?: string;

--- a/packages/components/input/types/input.d.ts
+++ b/packages/components/input/types/input.d.ts
@@ -1,4 +1,6 @@
 export interface TSInputHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Show error style  */
 	hasError?: boolean;
 

--- a/packages/components/label/types/label.d.ts
+++ b/packages/components/label/types/label.d.ts
@@ -1,4 +1,6 @@
 export interface TSLabelHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	for?: string;
 
 }

--- a/packages/components/list-item/types/list-item.d.ts
+++ b/packages/components/list-item/types/list-item.d.ts
@@ -1,4 +1,6 @@
 export interface TSListItemHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	title?: string;
 
 	subtitle?: string;

--- a/packages/components/modal/types/modal.d.ts
+++ b/packages/components/modal/types/modal.d.ts
@@ -1,4 +1,6 @@
 export interface TSModalHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction 'rtl' or 'ltr'  */
 	"data-dir"?: string;
 

--- a/packages/components/note/types/note.d.ts
+++ b/packages/components/note/types/note.d.ts
@@ -1,4 +1,6 @@
 export interface TSNoteHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	icon?: string;
 
 	type?: string;
@@ -9,7 +11,7 @@ export interface TSNoteHTMLAttributes {
 
 	hidden?: boolean;
 
-	buttons?: any[];
+	buttons?: string;
 
 }
 

--- a/packages/components/overlay/types/overlay.d.ts
+++ b/packages/components/overlay/types/overlay.d.ts
@@ -1,9 +1,11 @@
 export interface TSOverlayHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
 	/**  The element where the container will be rendered.  */
-	anchor?: object;
+	anchor?: string;
 
 	/**  Should the width be based on content (true) or inherited from the anchor (false).  */
 	autoWidth?: boolean;

--- a/packages/components/pager/types/pager.d.ts
+++ b/packages/components/pager/types/pager.d.ts
@@ -1,15 +1,17 @@
 export interface TSPagerHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Total number of pages  */
-	"total-pages"?: number;
+	"total-pages"?: string;
 
 	/**  Currently active page  */
-	"active-page"?: number;
+	"active-page"?: string;
 
 	/**  Determining maximum number of items in the page, should be either of 10,20,30,40,50  */
-	"per-page"?: number;
+	"per-page"?: string;
 
 	/**  Translated messages for the user locale  */
-	translations?: object;
+	translations?: string;
 
 }
 

--- a/packages/components/popover/types/popover.d.ts
+++ b/packages/components/popover/types/popover.d.ts
@@ -1,4 +1,6 @@
 export interface TSPopoverHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Is the popover visible or not  */
 	opened?: boolean;
 

--- a/packages/components/progress-bar/types/progress-bar.d.ts
+++ b/packages/components/progress-bar/types/progress-bar.d.ts
@@ -1,7 +1,9 @@
 export interface TSProgressBarHTMLAttributes {
-	total?: number;
+	/** css class name. Use it instead of "className" */
+	class?: string;
+	total?: string;
 
-	done?: number;
+	done?: string;
 
 	indeterminate?: boolean;
 

--- a/packages/components/radio-group/types/radio-group.d.ts
+++ b/packages/components/radio-group/types/radio-group.d.ts
@@ -1,4 +1,6 @@
 export interface TSRadioGroupHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Value of currently chosen ts-radio node  */
 	value?: string;
 
@@ -6,7 +8,7 @@ export interface TSRadioGroupHTMLAttributes {
 	title?: string;
 
 	/**  Index of checked ts-radio node  */
-	index?: number;
+	index?: string;
 
 	/**  Is group currently focused for keyboard input  */
 	focused?: boolean;

--- a/packages/components/radio/types/radio.d.ts
+++ b/packages/components/radio/types/radio.d.ts
@@ -1,4 +1,6 @@
 export interface TSRadioHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Value of the radio  */
 	value?: string;
 

--- a/packages/components/search/types/search.d.ts
+++ b/packages/components/search/types/search.d.ts
@@ -1,4 +1,6 @@
 export interface TSSearchHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Shoud the search be auto focused once page loaded  */
 	autofocus?: boolean;
 
@@ -9,7 +11,7 @@ export interface TSSearchHTMLAttributes {
 	focused?: boolean;
 
 	/**  timeout in ms for the 'idle' event  */
-	"idle-time"?: number;
+	"idle-time"?: string;
 
 	/**  Message when an input is empty  */
 	placeholder?: string;
@@ -18,7 +20,7 @@ export interface TSSearchHTMLAttributes {
 	value?: string;
 
 	/**  Translated messages for the user locale. <br> @type {{ loading: string, no_items: string }}  */
-	translations?: object;
+	translations?: string;
 
 	/**  Should dropdown items be rendered or not  */
 	"has-dropdown"?: boolean;
@@ -27,7 +29,7 @@ export interface TSSearchHTMLAttributes {
 	loading?: boolean;
 
 	/**  Dropdown items to show when user clicks on search component  */
-	"dropdown-items"?: any[];
+	"dropdown-items"?: string;
 
 }
 

--- a/packages/components/select-menu/types/select-menu.d.ts
+++ b/packages/components/select-menu/types/select-menu.d.ts
@@ -1,4 +1,6 @@
 export interface TSSelectMenuHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
@@ -6,10 +8,10 @@ export interface TSSelectMenuHTMLAttributes {
 	disabled?: boolean;
 
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
-	items?: any[];
+	items?: string;
 
 	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.  */
-	"filtered-items"?: any[];
+	"filtered-items"?: string;
 
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
@@ -18,10 +20,10 @@ export interface TSSelectMenuHTMLAttributes {
 	"no-apply-button"?: boolean;
 
 	/**  List of selected items' ids  */
-	selected?: any[];
+	selected?: string;
 
 	/**  Translated messages for the user locale  */
-	translations?: object;
+	translations?: string;
 
 	/**  Set component in loading state and render a spinner instead of list of items  */
 	loading?: boolean;

--- a/packages/components/select/types/select.d.ts
+++ b/packages/components/select/types/select.d.ts
@@ -1,4 +1,6 @@
 export interface TSSelectHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction of the component 'rtl' or 'ltr'.  */
 	dir?: string;
 
@@ -9,10 +11,10 @@ export interface TSSelectHTMLAttributes {
 	opened?: boolean;
 
 	/**  List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon  */
-	items?: any[];
+	items?: string;
 
 	/**  List of filtered options based on the select filter input value. `items` should be updated to always include all filtered items.    */
-	"filtered-items"?: any[];
+	"filtered-items"?: string;
 
 	/**  Allow users to select several options or not.  */
 	multiselect?: boolean;
@@ -21,13 +23,13 @@ export interface TSSelectHTMLAttributes {
 	"no-apply-button"?: boolean;
 
 	/**  List of selected items' ids  */
-	selected?: any[];
+	selected?: string;
 
 	/**  Default placeholder when there is no selection.  */
 	placeholder?: string;
 
 	/**  Translated messages for the user locale  */
-	translations?: object;
+	translations?: string;
 
 	/**  Show the loading spinner in select dropdown  */
 	loading?: boolean;
@@ -45,7 +47,7 @@ export interface TSSelectHTMLAttributes {
 	id?: string;
 
 	/**  Array of messages to pass to help-text component. See help-text component for more info   */
-	"help-text-messages"?: any[];
+	"help-text-messages"?: string;
 
 	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info   */
 	"help-text-title"?: string;
@@ -54,7 +56,7 @@ export interface TSSelectHTMLAttributes {
 	"help-text-type"?: string;
 
 	/**  Error messages to show underneath of the input when it has error  */
-	"error-messages"?: any[];
+	"error-messages"?: string;
 
 	/**  Error title, if there are more than one error message  */
 	"error-title"?: string;

--- a/packages/components/spinner/types/spinner.d.ts
+++ b/packages/components/spinner/types/spinner.d.ts
@@ -1,4 +1,6 @@
 export interface TSSpinnerHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Spinner color, `blue`, `mono`, `white`  */
 	"data-color"?: string;
 

--- a/packages/components/status/types/status.d.ts
+++ b/packages/components/status/types/status.d.ts
@@ -1,4 +1,6 @@
 export interface TSStatusHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	dir?: string;
 
 	status?: string;

--- a/packages/components/tab/types/tab.d.ts
+++ b/packages/components/tab/types/tab.d.ts
@@ -1,4 +1,6 @@
 export interface TSTabHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  The label text for the header  */
 	label?: string;
 
@@ -9,7 +11,7 @@ export interface TSTabHTMLAttributes {
 	icon?: string;
 
 	/**  Number for counter badge next to the label  */
-	counter?: number;
+	counter?: string;
 
 	/**  Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event   */
 	id?: string;

--- a/packages/components/tabs/types/tabs.d.ts
+++ b/packages/components/tabs/types/tabs.d.ts
@@ -1,4 +1,6 @@
 export interface TSTabsHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Direction (rtl/ltr)  */
 	dir?: string;
 

--- a/packages/components/tag/types/tag.d.ts
+++ b/packages/components/tag/types/tag.d.ts
@@ -1,4 +1,6 @@
 export interface TSTagHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Text direction: 'rtl' or 'ltr'  */
 	dir?: string;
 
@@ -15,10 +17,10 @@ export interface TSTagHTMLAttributes {
 	locked?: boolean;
 
 	/**  Array of labels or 'keys'  */
-	labels?: any[];
+	labels?: string;
 
 	/**  Array of values  */
-	values?: any[];
+	values?: string;
 
 	/**  Show busy/loading animation  */
 	busy?: boolean;

--- a/packages/components/text-field/types/text-field.d.ts
+++ b/packages/components/text-field/types/text-field.d.ts
@@ -1,4 +1,6 @@
 export interface TSTextFieldHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Label of the text field. If you need something more than simple string, use the label slot.  */
 	label?: string;
 
@@ -15,7 +17,7 @@ export interface TSTextFieldHTMLAttributes {
 	placeholder?: string;
 
 	/**  Array of messages to pass to help-text component. See help-text component for more info   */
-	"help-text-messages"?: any[];
+	"help-text-messages"?: string;
 
 	/**  If you have more than one help text message , you should pass a title to it. See help-text component for more info   */
 	"help-text-title"?: string;
@@ -24,7 +26,7 @@ export interface TSTextFieldHTMLAttributes {
 	"help-text-type"?: string;
 
 	/**  Error messages to show underneath of the input when it has error  */
-	"error-messages"?: any[];
+	"error-messages"?: string;
 
 	/**  Error title, if there are more than one error message  */
 	"error-title"?: string;

--- a/packages/components/tooltip/types/tooltip.d.ts
+++ b/packages/components/tooltip/types/tooltip.d.ts
@@ -1,4 +1,6 @@
 export interface TSTooltipHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	/**  Text that should be shown in the tooltip popover  */
 	tooltip?: string;
 

--- a/packages/components/typography/types/typography.d.ts
+++ b/packages/components/typography/types/typography.d.ts
@@ -1,4 +1,6 @@
 export interface TSTypographyHTMLAttributes {
+	/** css class name. Use it instead of "className" */
+	class?: string;
 	text?: string;
 
 	tooltip?: string;

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -36,8 +36,14 @@ const getExposedProperties = srcProps =>
 
 const getHtmlAttributeInterfaces = (typesFileContent, className, properties) => {
 	typesFileContent += `export interface TS${className}HTMLAttributes {${EOL}`;
+
+	// in React world for Web Components we should use "class" instead of "className"
+	typesFileContent += `\t/** css class name. Use it instead of "className" */${EOL}`;
+	typesFileContent += `\tclass?: string;${EOL}`;
 	properties.forEach(property => {
-		typesFileContent += generatePropertyLine(property.Attribute, property.Type, property.Description);
+		// HTML attributes can be one of two types: boolean or string
+		const htmlType = property.Type.toLowerCase() === 'boolean' ? property.Type : 'string';
+		typesFileContent += generatePropertyLine(property.Attribute, htmlType, property.Description);
 	});
 	typesFileContent += `}${EOL}${EOL}`;
 	return typesFileContent;


### PR DESCRIPTION
Made two fixes:
- Transform attr's types to be only string or boolean. According to HTML specification, element's attribute (aka `content attribute`) can be `string` or `boolean`: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#content_versus_idl_attributes
- Added a `class` attribute to all elements. In React developers should use `class` instead of `className` for Web Components to assign css classes: https://reactjs.org/docs/web-components.html#using-web-components-in-react