### PR TITLE
fix(select): import paths for svg assets

### DIFF
--- a/packages/components/help-text/src/help-text.js
+++ b/packages/components/help-text/src/help-text.js
@@ -1,7 +1,8 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper } from '@tradeshift/elements';
 import css from './help-text.css';
 import '@tradeshift/elements.icon';
-import { alert, info } from '@tradeshift/elements.icon/lib/assets/icons';
+import alert from '@tradeshift/elements.icon/lib/assets/icons/alert.svg';
+import info from '@tradeshift/elements.icon/lib/assets/icons/info.svg';
 
 import { sizes } from './utils';
 

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -2,7 +2,8 @@ import { customElementDefineHelper, html, TSElement, unsafeCSS } from '@tradeshi
 import '@tradeshift/elements.button';
 import '@tradeshift/elements.button-group';
 import '@tradeshift/elements.icon';
-import { checkbox as checkboxIcon, checkboxOn } from '@tradeshift/elements.icon/lib/assets/icons';
+import checkboxIcon from '@tradeshift/elements.icon/lib/assets/icons/checkbox.svg';
+import checkboxOn from '@tradeshift/elements.icon/lib/assets/icons/checkbox-on.svg';
 import '@tradeshift/elements.list-item';
 import '@tradeshift/elements.spinner';
 import css from './select-menu.css';

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -1,6 +1,6 @@
 import { TSElement, unsafeCSS, html, customElementDefineHelper, helpers } from '@tradeshift/elements';
 import '@tradeshift/elements.icon';
-import { arrowDownShort } from '@tradeshift/elements.icon/lib/assets/icons';
+import arrowDownShort from '@tradeshift/elements.icon/lib/assets/icons/arrow-down-short.svg';
 // eslint-disable-next-line import/no-duplicates
 import '@tradeshift/elements.overlay';
 // eslint-disable-next-line import/no-duplicates


### PR DESCRIPTION
- I am not sure if it's possible to use named imports for assets but I do know that default imports like the code changes below work. 

**Behaviour before merging this PR when running npm start locally** 
<img width="341" alt="ts-select-broken" src="https://user-images.githubusercontent.com/61288369/185199827-a9d3c6f5-9159-49a8-843f-72afda806a9b.png">

**Behaviour after merging this PR when running npm start locally** 
<img width="534" alt="ts-select-fixed" src="https://user-images.githubusercontent.com/61288369/185199877-720a730a-e98b-42ca-b3ee-9944ce7bbd68.png">

