### PR TITLE
PEAA-1317: fix ts-card story and stories order

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,7 @@
 import '@webcomponents/webcomponentsjs';
+
+export const parameters = {
+	options: {
+		storySort: (a, b) => (a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }))
+	}
+};

--- a/packages/components/card/stories/card.stories.js
+++ b/packages/components/card/stories/card.stories.js
@@ -52,8 +52,11 @@ export const Default = () => {
 	const content = text('content', defaultContent);
 	const rtl = boolean('rtl', false);
 
+	const contentDiv = document.createElement('div');
+	contentDiv.innerHTML = content;
+
 	return html`
-		<ts-card ?rtl="${rtl}" type="${type}" size="${size}" orientation="${orientation}"> ${html([content])} </ts-card>
+		<ts-card ?rtl="${rtl}" type="${type}" size="${size}" orientation="${orientation}">${contentDiv}</ts-card>
 	`;
 };
 


### PR DESCRIPTION
- fixed error with custom HTML in `ts-card` story. Made it the same way as we have in `ts-board` story.
- Made order of stories alphabetical. Documentation: https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#sorting-stories