### PR TITLE
PEAA-1389: allow number type in html attributes

### DIFF
--- a/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
+++ b/packages/components/date-picker-overlay/types/date-picker-overlay.d.ts
@@ -5,7 +5,7 @@ export interface TSDatePickerOverlayHTMLAttributes {
 
 	translations?: string;
 
-	firstDay?: string;
+	firstDay?: number | string;
 
 	pageDate?: string;
 

--- a/packages/components/date-picker/types/date-picker.d.ts
+++ b/packages/components/date-picker/types/date-picker.d.ts
@@ -38,7 +38,7 @@ export interface TSDatePickerHTMLAttributes {
 	"not-typeable"?: boolean | 'true' | 'false';
 
 	/**  Which day should be shown as the first day of the week. A number between 0-6 (0 = Sunday, 6 = Saturday)  */
-	"first-day"?: string;
+	"first-day"?: number | string;
 
 	/**  Array of messages to pass to help-text component. See help-text component for more info  */
 	"help-text-messages"?: string;

--- a/packages/components/file-size/types/file-size.d.ts
+++ b/packages/components/file-size/types/file-size.d.ts
@@ -2,10 +2,10 @@ export interface TSFileSizeHTMLAttributes {
 	/** css class name. Use it instead of "className" */
 	class?: string;
 	/**  Size of the file  */
-	size?: string;
+	size?: number | string;
 
 	/**  How many decimal points should be shown  */
-	"decimal-point"?: string;
+	"decimal-point"?: number | string;
 
 	/**  Typography variant  */
 	variant?: string;

--- a/packages/components/file-uploader-input/types/file-uploader-input.d.ts
+++ b/packages/components/file-uploader-input/types/file-uploader-input.d.ts
@@ -29,7 +29,7 @@ export interface TSFileUploaderInputHTMLAttributes {
 	"hide-max-file-number-help-text"?: boolean | 'true' | 'false';
 
 	/**  Maximum limit for number of files to be shown as helper message  */
-	"max-file-number"?: string;
+	"max-file-number"?: number | string;
 
 }
 

--- a/packages/components/icon/types/icon.d.ts
+++ b/packages/components/icon/types/icon.d.ts
@@ -17,7 +17,7 @@ export interface TSIconHTMLAttributes {
 	circular?: boolean | 'true' | 'false';
 
 	/**  90, 180, 270  */
-	rotate?: string;
+	rotate?: number | string;
 
 	/**  'h', 'horizontal', 'v', 'vertical'  */
 	flip?: string;

--- a/packages/components/pager/types/pager.d.ts
+++ b/packages/components/pager/types/pager.d.ts
@@ -2,13 +2,13 @@ export interface TSPagerHTMLAttributes {
 	/** css class name. Use it instead of "className" */
 	class?: string;
 	/**  Total number of pages  */
-	"total-pages"?: string;
+	"total-pages"?: number | string;
 
 	/**  Currently active page  */
-	"active-page"?: string;
+	"active-page"?: number | string;
 
 	/**  Determining maximum number of items in the page, should be either of 10,20,30,40,50  */
-	"per-page"?: string;
+	"per-page"?: number | string;
 
 	/**  Translated messages for the user locale  */
 	translations?: string;

--- a/packages/components/progress-bar/types/progress-bar.d.ts
+++ b/packages/components/progress-bar/types/progress-bar.d.ts
@@ -1,9 +1,9 @@
 export interface TSProgressBarHTMLAttributes {
 	/** css class name. Use it instead of "className" */
 	class?: string;
-	total?: string;
+	total?: number | string;
 
-	done?: string;
+	done?: number | string;
 
 	indeterminate?: boolean | 'true' | 'false';
 

--- a/packages/components/radio-group/types/radio-group.d.ts
+++ b/packages/components/radio-group/types/radio-group.d.ts
@@ -8,7 +8,7 @@ export interface TSRadioGroupHTMLAttributes {
 	title?: string;
 
 	/**  Index of checked ts-radio node  */
-	index?: string;
+	index?: number | string;
 
 	/**  Is group currently focused for keyboard input  */
 	focused?: boolean | 'true' | 'false';

--- a/packages/components/search/types/search.d.ts
+++ b/packages/components/search/types/search.d.ts
@@ -11,7 +11,7 @@ export interface TSSearchHTMLAttributes {
 	focused?: boolean | 'true' | 'false';
 
 	/**  timeout in ms for the 'idle' event  */
-	"idle-time"?: string;
+	"idle-time"?: number | string;
 
 	/**  Message when an input is empty  */
 	placeholder?: string;

--- a/packages/components/tab/types/tab.d.ts
+++ b/packages/components/tab/types/tab.d.ts
@@ -11,7 +11,7 @@ export interface TSTabHTMLAttributes {
 	icon?: string;
 
 	/**  Number for counter badge next to the label  */
-	counter?: string;
+	counter?: number | string;
 
 	/**  Id of the tab which will be added to the tab button in the header of tabs. It can also be used for identifying the tab on tab-click event   */
 	id?: string;

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -74,6 +74,9 @@ function htmlTypeToTypescriptType(htmlType) {
 	switch (htmlType.toLowerCase()) {
 		case 'boolean':
 			return `boolean | 'true' | 'false'`;
+		case 'number':
+			// since React v16 it will cast to string any value, and for numbers it should be safe
+			return 'number | string';
 		default:
 			return 'string';
 	}


### PR DESCRIPTION
Since v16 of React it will cast all unknown attributes to string, so we can safely allow number as an acceptable type where already expect number.
It will simplify Dev experience when the parameter is number but they need to cast it to string if they want to pass it in JSX as an html attribute.
How it looks now:
<img width="454" alt="Screen Shot 2022-11-02 at 12 09 58 PM" src="https://user-images.githubusercontent.com/55530374/199709914-fbc00dcb-1f09-4251-b744-f7c247216c9c.png">

Some information about React behaviour: https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html
How it works under the hood: https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/client/DOMPropertyOperations.js#L223