### PR TITLE
Install dependencies before bootstrap in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,10 @@ jobs:
         with:
           node-version: 16
 
-      - name: 📥 Download
+      - name: 📥 Download dependencies
+        run: npm ci
+
+      - name: Bootstrap monorepo
         run: npm run lerna:bootstrap:ci
 
       - name: ▶️ Lint and build


### PR DESCRIPTION
We need to install dependencies first to make sure scripts will use the correct version of lerna.