### PR TITLE
chore(release): v0.40.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
 
       - name: 📥 Download dependencies
         run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,11 @@
+name: npm publish
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  npm-publish:
+    uses: tradeshift/actions-workflow-npm/.github/workflows/comment-npm-publish.yml@v1
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      npm-read-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
 
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
           registry-url: 'https://npm.pkg.github.com'
           cache: npm
           scope: '@tradeshift'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+### Bug Fixes
+
+- add perPageOptions property for customizable items per page ([f5a3e06](https://github.com/Tradeshift/elements/commit/f5a3e06d011043d99c34e0ef9ceaed6abe8dcc6d))
+- **build:** decommission dependency-auto-update workflow(SRE-4172) ([a6244d3](https://github.com/Tradeshift/elements/commit/a6244d32bf8321a5d3c50248e1e0caf5c9cba8d5))
+- **deps:** update dependency lit-element to ^2.5.1 ([#560](https://github.com/Tradeshift/elements/issues/560)) ([674959f](https://github.com/Tradeshift/elements/commit/674959fec02fe9d3e1de12574f6f23ed076e5ff6))
+- **deps:** update dependency lit-element to ^4.0.5 ([66fcf1b](https://github.com/Tradeshift/elements/commit/66fcf1bb7c64b15216d580fd47aad47701725c12))
+- **deps:** update dependency lit-element to ^4.0.6 ([927df09](https://github.com/Tradeshift/elements/commit/927df095c0d9629f16f674d356c0b8850635c916))
+- **deps:** update dependency lit-element to ^4.1.0 ([59c917c](https://github.com/Tradeshift/elements/commit/59c917ca46b24e98d38ceee21c3072f44b692dba))
+- **deps:** update dependency lit-element to ^4.2.0 ([62d3590](https://github.com/Tradeshift/elements/commit/62d359039980108dc82992edb4878c979f3c16b4))
+- **deps:** update dependency lit-element to ^4.2.1 ([f6aae99](https://github.com/Tradeshift/elements/commit/f6aae99671d3887abbba04d565b7e27e1fe97a8c))
+- **deps:** update dependency lit-element to ^4.2.2 ([34aca09](https://github.com/Tradeshift/elements/commit/34aca0942f4682f4da9724b46edade994783f184))
+- **deps:** update dependency lit-element to v4 ([#591](https://github.com/Tradeshift/elements/issues/591)) ([681aaad](https://github.com/Tradeshift/elements/commit/681aaad7692f6841d45f04582917491daf890612))
+- update module imports to support default exports ([1825ab1](https://github.com/Tradeshift/elements/commit/1825ab1130d05e8b6efdb0ea8ac656dfa21e53fa))
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<meta charset="UTF-8" />

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
 			"message": "chore(release): %s"
 		}
 	},
-	"version": "0.40.2"
+	"version": "0.40.3"
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "Kirill Kolombet <kirill.kolombet@tradeshift.com> (https://github.com/kirill-kolombet)"
   ],
   "scripts": {
+    "add-desc-to-src": "cross-env-shell node ./scripts/add-description-to-src.js",
     "build": "cross-env-shell lerna run pre-build && lerna exec -- rollup -c=`pwd`/rollup.config.js",
-    "build-storybook": "build-storybook -s ./static -o .out",
     "build:prod": "cross-env PRODUCTION=true npm run build",
+    "build-storybook": "build-storybook -s ./static -o .out",
     "check-credentials": "npm whoami && npm whoami --registry=https://npm.pkg.github.com/ && npm whoami --registry=https://registry.npmjs.org/",
     "check-deps": "lerna exec --stream --no-bail \"depcheck --ignores=\"lit-html,@storybook/*\" --ignore-patterns=lib,types\"",
     "clean": "cross-env-shell lerna exec -- rm -rf ./lib/*",
@@ -41,15 +42,17 @@
     "copy:static": "./tasks/copy-static.sh",
     "dev": "run-p watch server-reload",
     "format": "cross-env-shell prettier --config `pwd`/.prettierrc --write \"packages/**/README.md\" \"packages/**/*.{js,json,css}\" \"index.{css,html}\"",
+    "generate-types": "cross-env-shell node ./scripts/generate-types.js",
     "happo": "happo",
     "happo-ci-github-actions": "happo-ci-github-actions",
-    "lerna-clean": "cross-env-shell lerna clean",
     "lerna:bootstrap:ci": "lerna bootstrap --hoist --ci",
+    "lerna-clean": "cross-env-shell lerna clean",
+    "lerna-publish-beta": "lerna publish from-package --dist-tag beta --no-verify-access",
     "lerna-publish-ci": "lerna publish from-package --no-verify-access",
     "lerna-version": "lerna version --conventional-commits --yes --no-push",
     "lint": "cross-env-shell eslint --config `pwd`/.eslintrc --color \"packages/**/**/{src,stories}/**/*.js\"",
     "new-version": "sh ./scripts/new-version.sh",
-    "preversion": "run-s update-doc-src-from-readme update-readme generate-types format",
+    "prepare": "husky install",
     "server": "web-dev-server --node-resolve --open",
     "server-reload": "reload --browser --exts html,umd.js",
     "stage": "lint-staged",
@@ -63,10 +66,8 @@
     "test": "npm run happo",
     "update-doc-src-from-readme": "cross-env-shell node ./scripts/from-readme/index.js",
     "update-readme": "cross-env-shell node ./scripts/update-readme-files.js",
-    "add-desc-to-src": "cross-env-shell node ./scripts/add-description-to-src.js",
-    "generate-types": "cross-env-shell node ./scripts/generate-types.js",
-    "watch": "cross-env-shell lerna exec --parallel -- rollup -w -c=`pwd`/rollup.config.js",
-    "prepare": "husky install"
+    "preversion": "run-s update-doc-src-from-readme update-readme generate-types format",
+    "watch": "cross-env-shell lerna exec --parallel -- rollup -w -c=`pwd`/rollup.config.js"
   },
   "lint-staged": {
     "*.js": [
@@ -85,6 +86,17 @@
     "> 1%",
     "IE 11"
   ],
+  "overrides": {
+    "@storybook/addon-notes@5.3.21": {
+      "react-syntax-highlighter": ">=15.5.0"
+    },
+    "@storybook/storybook-deployer": {
+      "parse-url": "8.1.0"
+    },
+    "glob-parent": ">=6.0.2",
+    "trim": ">=1.0.1",
+    "trim-newlines": "^5.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
@@ -133,17 +145,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "overrides": {
-    "@storybook/addon-notes@5.3.21": {
-      "react-syntax-highlighter": ">=15.5.0"
-    },
-    "@storybook/storybook-deployer": {
-      "parse-url": "8.1.0"
-    },
-    "trim-newlines": "^5.0.0",
-    "glob-parent": ">=6.0.2",
-    "trim": ">=1.0.1"
   },
   "storybook-deployer": {
     "gitUsername": "Tradeshift Elements",

--- a/packages/components/action-select/CHANGELOG.md
+++ b/packages/components/action-select/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.action-select
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.action-select

--- a/packages/components/action-select/README.md
+++ b/packages/components/action-select/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | opened | opened | Boolean | false | Is the action select opened or not |
@@ -40,13 +40,13 @@
 ## ➤ Slots
 
 | Name    | Description                                                                                         |
-| ------- | --------------------------------------------------------------------------------------------------- |
+| :------ | :-------------------------------------------------------------------------------------------------- |
 | default | Element in this slot becomes the anchor for the action menu. When empty, it will render a menu icon |
 
 ## ➤ Events
 
 | Name                | Description                         | Payload      |
-| ------------------- | ----------------------------------- | ------------ |
+| :------------------ | :---------------------------------- | :----------- |
 | action-select-click | Emitted when user clicks on an item | { selected } |
 
 ## ➤ How to use it

--- a/packages/components/action-select/package.json
+++ b/packages/components/action-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.action-select",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,11 +15,11 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.overlay": "^0.40.2",
-    "@tradeshift/elements.select-menu": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.overlay": "^0.40.3",
+    "@tradeshift/elements.select-menu": "^0.40.3"
   },
   "src": "src/action-select.js"
 }

--- a/packages/components/app-icon/CHANGELOG.md
+++ b/packages/components/app-icon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.app-icon
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.app-icon

--- a/packages/components/app-icon/README.md
+++ b/packages/components/app-icon/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type   | Default | Description                                                    |
-| -------- | --------- | ------ | ------- | -------------------------------------------------------------- |
+| :------- | :-------- | :----- | :------ | :------------------------------------------------------------- |
 | size     | size      | String |         | Size of the app icon, available variants: ''(default), 'large' |
 | src      | src       | String |         | Specifies the URL of an image                                  |
 | alt      | alt       | String |         | Specifies an alternate text for an image                       |

--- a/packages/components/app-icon/package.json
+++ b/packages/components/app-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.app-icon",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/app-icon.js"
 }

--- a/packages/components/aside/CHANGELOG.md
+++ b/packages/components/aside/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.aside
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.aside

--- a/packages/components/aside/README.md
+++ b/packages/components/aside/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
 | title | data-title | String | '' | Aside header title |
 | visible | data-visible | Boolean | false | Show/hide aside |
@@ -43,7 +43,7 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | note | Use this slot name on the \`ts-note\` in the aside |
 | platform-object | The section between aside header and content that platform object should be shown with different background color |
 | main | Main content of the aside that doesn't fit into any other available slots |
@@ -52,7 +52,7 @@
 ## ➤ Events
 
 | Name   | Description                                  | Payload |
-| ------ | -------------------------------------------- | ------- |
+| :----- | :------------------------------------------- | :------ |
 | open   | Emitted when the aside is about to be opened |         |
 | close  | Emitted when the aside is about to be closed |         |
 | opened | Emitted when the aside has been opened       |         |

--- a/packages/components/aside/package.json
+++ b/packages/components/aside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.aside",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,11 +15,11 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.cover": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.spinner": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.cover": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.spinner": "^0.40.3"
   },
   "src": "src/aside.js"
 }

--- a/packages/components/aside/src/aside.css
+++ b/packages/components/aside/src/aside.css
@@ -125,7 +125,9 @@
 .ts-slide-out-left {
 	visibility: hidden;
 	opacity: 0;
-	transition: visibility 0s var(--ts-transition-fast), opacity var(--ts-transition-fast) linear;
+	transition:
+		visibility 0s var(--ts-transition-fast),
+		opacity var(--ts-transition-fast) linear;
 }
 
 .ts-slide-out-right {

--- a/packages/components/basic-table/CHANGELOG.md
+++ b/packages/components/basic-table/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.basic-table
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.basic-table

--- a/packages/components/basic-table/README.md
+++ b/packages/components/basic-table/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
 | cols | cols | Array | [] | <br> List of columns configs, including: <br> - property: Property key of the column in data object, <br> - value: value of the title of column', <br> - visibility?: Which screen sizes this column should be visible -> 'always-visible'(default) or 'desktop-only' or 'mobile-only', <br> - size?: 'small' or 'medium' or 'large', <br> - display?: 'left' or 'right' or 'center', <br> - renderer?: you can pass a renderer function to customize the content of the cells in this column, args: (cellValue, rowObject) <br> |
 | selectedIds | selectedIds | Array | [] | List of selected rows ids (caveat: the row should include id property) |
@@ -40,7 +40,7 @@
 ## ➤ Events
 
 | Name      | Description                | Payload |
-| --------- | -------------------------- | ------- |
+| :-------- | :------------------------- | :------ |
 | row-click | Emitted on table row click | { row } |
 
 ## ➤ How to use it

--- a/packages/components/basic-table/package.json
+++ b/packages/components/basic-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.basic-table",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.document-card": "^0.40.2",
-    "@tradeshift/elements.status": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.document-card": "^0.40.3",
+    "@tradeshift/elements.status": "^0.40.3"
   },
   "src": "src/basic-table.js"
 }

--- a/packages/components/basic-table/src/basic-table.js
+++ b/packages/components/basic-table/src/basic-table.js
@@ -106,12 +106,11 @@ export class TSBasicTable extends TSElement {
 
 	tableRow(row) {
 		return this.cols.map(
-			column =>
-				html`
-					<td class="${this.getVisibilityClass(column.visibility)}">
-						${this.renderTableCell(row[column.property], column, row)}
-					</td>
-				`
+			column => html`
+				<td class="${this.getVisibilityClass(column.visibility)}">
+					${this.renderTableCell(row[column.property], column, row)}
+				</td>
+			`
 		);
 	}
 

--- a/packages/components/board/CHANGELOG.md
+++ b/packages/components/board/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.board
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.board

--- a/packages/components/board/README.md
+++ b/packages/components/board/README.md
@@ -31,14 +31,14 @@
 ## ➤ Properties
 
 | Property | Attribute  | Type   | Default | Description                               |
-| -------- | ---------- | ------ | ------- | ----------------------------------------- |
+| :------- | :--------- | :----- | :------ | :---------------------------------------- |
 | dir      | dir        | String | ltr     | Direction of the component 'rtl' or 'ltr' |
 | title    | data-title | String |         | Board header title                        |
 
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | header-actions | To add action items like buttons and action-select to the header (opposite side of the title).For having header-actions, it is required for the board to have a title. |
 | default | Content of the board should be wrapped around \`ts-board\` element |
 

--- a/packages/components/board/package.json
+++ b/packages/components/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.board",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.action-select": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.action-select": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3"
   },
   "src": "src/board.js"
 }

--- a/packages/components/button-group/CHANGELOG.md
+++ b/packages/components/button-group/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.button-group
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.button-group

--- a/packages/components/button-group/README.md
+++ b/packages/components/button-group/README.md
@@ -31,14 +31,14 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
 | inline | inline | Boolean | false | Make the buttons inline instead of stacking which is the default behaviour |
 
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | default | All \`ts-button\` elements in the group should be wrapped with \`ts-button-group\` element to be grouped together |
 
 ## ➤ How to use it

--- a/packages/components/button-group/package.json
+++ b/packages/components/button-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button-group",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3"
   },
   "src": "src/button-group.js"
 }

--- a/packages/components/button/CHANGELOG.md
+++ b/packages/components/button/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.button
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.button

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | type | type | String |  | Button type to have different style `primary`, `secondary`, `text`, `accept`, `warning`, `danger` |
 | size | size | String |  | Size of the button, `macro`, `micro` |
 | busy | busy | Boolean | false | Show busy/loading animation |
@@ -47,13 +47,13 @@
 ## ➤ Slots
 
 | Name    | Description                                                       |
-| ------- | ----------------------------------------------------------------- |
+| :------ | :---------------------------------------------------------------- |
 | default | Text of the button should be wrapped around \`ts-button\` element |
 
 ## ➤ Events
 
 | Name         | Description |
-| ------------ | ----------- |
+| :----------- | :---------- |
 | button-click |             |
 
 ## ➤ How to use it

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.button",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/button.js"
 }

--- a/packages/components/card/CHANGELOG.md
+++ b/packages/components/card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.card
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.card

--- a/packages/components/card/README.md
+++ b/packages/components/card/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property            | Attribute             | Type    | Default               | Description |
-| ------------------- | --------------------- | ------- | --------------------- | ----------- |
+| :------------------ | :-------------------- | :------ | :-------------------- | :---------- |
 | type                | type                  | String  | ''                    |             |
 | orientation         | orientation           | String  | orientations.VERTICAL |             |
 | rtl                 | rtl                   | Boolean | false                 |             |
@@ -43,7 +43,7 @@
 ## ➤ Slots
 
 | Name    | Description |
-| ------- | ----------- |
+| :------ | :---------- |
 | default |             |
 
 ## ➤ How to use it

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.card",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/card.js"
 }

--- a/packages/components/card/src/card.css
+++ b/packages/components/card/src/card.css
@@ -12,7 +12,9 @@
 	overflow: hidden;
 	padding: var(--ts-unit-half);
 	background-color: var(--ts-color-white);
-	transition: box-shadow var(--ts-transition-now), border-color var(--ts-transition-now);
+	transition:
+		box-shadow var(--ts-transition-now),
+		border-color var(--ts-transition-now);
 
 	&:hover {
 		box-shadow: var(--ts-boxshadow-border-hover);
@@ -44,7 +46,9 @@
 	box-shadow: var(--ts-boxshadow-border-error);
 
 	&:hover {
-		box-shadow: var(--ts-boxshadow-border-error), 0 0 0 1px var(--ts-color-red-lighter);
+		box-shadow:
+			var(--ts-boxshadow-border-error),
+			0 0 0 1px var(--ts-color-red-lighter);
 	}
 }
 
@@ -52,7 +56,9 @@
 	box-shadow: var(--ts-boxshadow-border-success);
 
 	&:hover {
-		box-shadow: var(--ts-boxshadow-border-success), 0 0 0 1px var(--ts-color-green-lighter);
+		box-shadow:
+			var(--ts-boxshadow-border-success),
+			0 0 0 1px var(--ts-color-green-lighter);
 	}
 }
 

--- a/packages/components/checkbox/CHANGELOG.md
+++ b/packages/components/checkbox/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.checkbox
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.checkbox

--- a/packages/components/checkbox/README.md
+++ b/packages/components/checkbox/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | name | name | String | '' | Name of checkbox |
 | value | value | String |  | Value of checkbox |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr' |
@@ -43,7 +43,7 @@
 ## ➤ Slots
 
 | Name    | Description                                                                                    |
-| ------- | ---------------------------------------------------------------------------------------------- |
+| :------ | :--------------------------------------------------------------------------------------------- |
 | default | To customized checkbox label (links, ...). Remember you need to remove 'data-label' attribute. |
 
 ## ➤ How to use it

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.checkbox",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/checkbox.js"
 }

--- a/packages/components/checkbox/src/checkbox.js
+++ b/packages/components/checkbox/src/checkbox.js
@@ -57,7 +57,7 @@ export class TSCheckbox extends TSElement {
 					: html`
 							<!-- To customized checkbox label (links, ...). Remember you need to remove 'data-label' attribute. -->
 							<slot></slot>
-					  `}
+						`}
 			</div>
 		`;
 	}

--- a/packages/components/confirmation-prompt/CHANGELOG.md
+++ b/packages/components/confirmation-prompt/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.confirmation-prompt
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.confirmation-prompt

--- a/packages/components/confirmation-prompt/README.md
+++ b/packages/components/confirmation-prompt/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | visible | data-visible | Boolean | false | Dialog can be toggled by add/removing this attribute |
 | header | data-header | String |  | Header of the modal |
 | title | data-title | String |  | Title on top of the text part |
@@ -47,14 +47,14 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | title | If in rare cases you need to have more complex title than text property, you can override the title by using this slot |
 | content | If in rare cases you need to have more complex content than text property, you can override the text by using this slot |
 
 ## ➤ Events
 
 | Name | Description | Payload |
-| --- | --- | --- |
+| :-- | :-- | :-- |
 | accept | Emitted when the user choose the accept option |  |
 | cancel | Emitted when the user choose the cancel option |  |
 | close | Emitted when the user dismiss the modal, includes cancel button click, close button click, backdrop cover click |  |

--- a/packages/components/confirmation-prompt/package.json
+++ b/packages/components/confirmation-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.confirmation-prompt",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.modal": "^0.40.2",
-    "@tradeshift/elements.text-field": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.modal": "^0.40.3",
+    "@tradeshift/elements.text-field": "^0.40.3"
   },
   "src": "src/confirmation-prompt.js"
 }

--- a/packages/components/cover/CHANGELOG.md
+++ b/packages/components/cover/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.cover
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.cover

--- a/packages/components/cover/README.md
+++ b/packages/components/cover/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute    | Type    | Default | Description |
-| -------- | ------------ | ------- | ------- | ----------- |
+| :------- | :----------- | :------ | :------ | :---------- |
 | visible  | data-visible | Boolean | false   |             |
 
 ## ➤ How to use it

--- a/packages/components/cover/package.json
+++ b/packages/components/cover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.cover",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/cover.js"
 }

--- a/packages/components/cover/src/cover.css
+++ b/packages/components/cover/src/cover.css
@@ -16,13 +16,17 @@
 .ts-fadeIn {
 	visibility: visible;
 	opacity: 0.8;
-	transition: visibility var(--ts-transition-now) linear var(--ts-transition-now), opacity var(--ts-transition-fast);
+	transition:
+		visibility var(--ts-transition-now) linear var(--ts-transition-now),
+		opacity var(--ts-transition-fast);
 }
 
 .ts-fadeOut {
 	visibility: hidden;
 	opacity: 0;
-	transition: visibility var(--ts-transition-now) linear var(--ts-transition-fast), opacity var(--ts-transition-fast);
+	transition:
+		visibility var(--ts-transition-now) linear var(--ts-transition-fast),
+		opacity var(--ts-transition-fast);
 }
 
 :host(.ts-aside-cover) {

--- a/packages/components/date-picker-overlay/CHANGELOG.md
+++ b/packages/components/date-picker-overlay/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.date-picker-overlay
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/date-picker-overlay/README.md
+++ b/packages/components/date-picker-overlay/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property          | Attribute         | Type     | Default | Description |
-| ----------------- | ----------------- | -------- | ------- | ----------- |
+| :---------------- | :---------------- | :------- | :------ | :---------- |
 | dir               | dir               | String   | ltr     |             |
 | translations      | translations      | Object   |         |             |
 | firstDay          | firstDay          | Number   |         |             |
@@ -43,7 +43,7 @@
 ## ➤ Events
 
 | Name                 | Description |
-| -------------------- | ----------- |
+| :------------------- | :---------- |
 | selected-date-change |             |
 
 ## ➤ How to use it

--- a/packages/components/date-picker-overlay/package.json
+++ b/packages/components/date-picker-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker-overlay",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/date-picker-overlay/src/date-picker-overlay.js
+++ b/packages/components/date-picker-overlay/src/date-picker-overlay.js
@@ -160,9 +160,7 @@ export class TSDatePickerOverlay extends TSElement {
 		for (let i = 0; i < this.firstDay; i++) {
 			weekDays.push(weekDays.shift());
 		}
-		return html`${weekDays.map(
-			day => html`<span class="day-name">${this.translations.daysAbbreviations[day]}</span>`
-		)}`;
+		return html`${weekDays.map(day => html`<span class="day-name">${this.translations.daysAbbreviations[day]}</span>`)}`;
 	}
 
 	render() {

--- a/packages/components/date-picker/CHANGELOG.md
+++ b/packages/components/date-picker/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.date-picker
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/date-picker/README.md
+++ b/packages/components/date-picker/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | translations | translations | Object |  | Can be used for customizing placeholder, days abbreviations, months abbreviations and providing translations for them <br> see the structure in its storybook knobs section. <br> |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | selectedDate | selected-date | String |  | For setting the date of the date picker you can use this prop/attribute. It will get update after the user changes the date. |
@@ -57,7 +57,7 @@
 ## ➤ Events
 
 | Name        | Description                         | Payload        |
-| ----------- | ----------------------------------- | -------------- |
+| :---------- | :---------------------------------- | :------------- |
 | date-select | Emitted when user select a new date | {selectedDate} |
 
 ## ➤ How to use it

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.date-picker",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,11 +15,11 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.date-picker-overlay": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.overlay": "^0.40.2",
-    "@tradeshift/elements.text-field": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.date-picker-overlay": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.overlay": "^0.40.3",
+    "@tradeshift/elements.text-field": "^0.40.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/date-picker/src/date-picker.js
+++ b/packages/components/date-picker/src/date-picker.js
@@ -295,7 +295,7 @@ export class TSDatePicker extends TSElement {
 									@selected-date-change=${this.onSelectedDateChange}
 								></ts-date-picker-overlay>
 							</ts-overlay>
-					  `
+						`
 					: ''}
 			</div>
 		`;

--- a/packages/components/dialog/CHANGELOG.md
+++ b/packages/components/dialog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.dialog
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.dialog

--- a/packages/components/dialog/README.md
+++ b/packages/components/dialog/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | visible | data-visible | Boolean | false | Dialog can be toggled by adding/removing this attribute |
 | text | text | String |  | Text content of the modal |
 | icon | icon | String |  | If you need a different icon that default ones, you can use one of Elements icon names. Notifications will ignore this |
@@ -46,14 +46,14 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | content | If in rare cases you need to have more complex content than text property, you can override the text by using this slot |
 | extra-buttons | To add more options to the dialog (notifications will ignore extra buttons), between accept and cancel buttons |
 
 ## ➤ Events
 
 | Name   | Description                                    | Payload |
-| ------ | ---------------------------------------------- | ------- |
+| :----- | :--------------------------------------------- | :------ |
 | accept | Emitted when the user choose the accept option |         |
 | cancel | Emitted when the user choose the cancel option |         |
 

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.dialog",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.button-group": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.modal": "^0.40.2",
-    "@tradeshift/elements.typography": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.button-group": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.modal": "^0.40.3",
+    "@tradeshift/elements.typography": "^0.40.3"
   },
   "src": "src/dialog.js"
 }

--- a/packages/components/document-card/CHANGELOG.md
+++ b/packages/components/document-card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.document-card
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.document-card

--- a/packages/components/document-card/README.md
+++ b/packages/components/document-card/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property          | Attribute          | Type    | Default | Description |
-| ----------------- | ------------------ | ------- | ------- | ----------- |
+| :---------------- | :----------------- | :------ | :------ | :---------- |
 | dir               | dir                | String  | ltr     |             |
 | name              | name               | String  | ''      |             |
 | description       | description        | String  | ''      |             |

--- a/packages/components/document-card/package.json
+++ b/packages/components/document-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.document-card",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/document-card.js"
 }

--- a/packages/components/file-card/CHANGELOG.md
+++ b/packages/components/file-card/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.file-card
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.file-card

--- a/packages/components/file-card/README.md
+++ b/packages/components/file-card/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | state | state | String | states.UPLOADING | type/state of the file card: 'download', 'failed', 'uploading' |
 | fileObject | file-object | Object |  | File data object, {name, size, ...} |
 | rtl | rtl | Boolean | false |  |
@@ -42,14 +42,14 @@
 ## ➤ Slots
 
 | Name                 | Description                              |
-| -------------------- | ---------------------------------------- |
+| :------------------- | :--------------------------------------- |
 | remove-action-text   | To customize the remove action message   |
 | download-action-text | To customize the download action message |
 
 ## ➤ Events
 
 | Name   | Description                                | Payload  |
-| ------ | ------------------------------------------ | -------- |
+| :----- | :----------------------------------------- | :------- |
 | remove | Emitted when user clicks the remove action | { file } |
 
 ## ➤ How to use it

--- a/packages/components/file-card/package.json
+++ b/packages/components/file-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-card",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.card": "^0.40.2",
-    "@tradeshift/elements.file-size": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.progress-bar": "^0.40.2",
-    "@tradeshift/elements.typography": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.card": "^0.40.3",
+    "@tradeshift/elements.file-size": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.progress-bar": "^0.40.3",
+    "@tradeshift/elements.typography": "^0.40.3"
   },
   "src": "src/file-card.js"
 }

--- a/packages/components/file-size/CHANGELOG.md
+++ b/packages/components/file-size/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.file-size
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/file-size/README.md
+++ b/packages/components/file-size/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property     | Attribute     | Type   | Default    | Description                             |
-| ------------ | ------------- | ------ | ---------- | --------------------------------------- |
+| :----------- | :------------ | :----- | :--------- | :-------------------------------------- |
 | size         | size          | Number | 0          | Size of the file                        |
 | decimalPoint | decimal-point | Number | 2          | How many decimal points should be shown |
 | variant      | variant       | String | 'subtitle' | Typography variant                      |

--- a/packages/components/file-size/package.json
+++ b/packages/components/file-size/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-size",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.typography": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.typography": "^0.40.3"
   },
   "src": "src/file-size.js"
 }

--- a/packages/components/file-uploader-input/CHANGELOG.md
+++ b/packages/components/file-uploader-input/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.file-uploader-input
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/file-uploader-input/README.md
+++ b/packages/components/file-uploader-input/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | rtl | rtl | Boolean | false |  |
 | disabled | disabled | Boolean | false | Disable the input |
 | multiple | multiple | Boolean | false | Allow multiple file select. |
@@ -48,14 +48,14 @@
 ## ➤ Slots
 
 | Name             | Description                    |
-| ---------------- | ------------------------------ |
+| :--------------- | :----------------------------- |
 | placeholder-text | Customize the placeholder text |
 | button-text      | Customize the button text      |
 
 ## ➤ Events
 
 | Name   | Description               | Payload                  |
-| ------ | ------------------------- | ------------------------ |
+| :----- | :------------------------ | :----------------------- |
 | change | Emitted on file(s) upload | { originalEvent, files } |
 
 ## ➤ How to use it

--- a/packages/components/file-uploader-input/package.json
+++ b/packages/components/file-uploader-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.file-uploader-input",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.help-text": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.help-text": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/file-uploader-input.js"
 }

--- a/packages/components/header/CHANGELOG.md
+++ b/packages/components/header/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.header
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.header

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type   | Default | Description                          |
-| -------- | --------- | ------ | ------- | ------------------------------------ |
+| :------- | :-------- | :----- | :------ | :----------------------------------- |
 | dir      | dir       | String | ltr     | Direction of the button `rtl`, `ltr` |
 | icon     | icon      | String |         | Icon shows in the header             |
 | title    | title     | String |         | Title shows in the header            |
@@ -40,7 +40,7 @@
 ## ➤ Slots
 
 | Name    | Description                                                                  |
-| ------- | ---------------------------------------------------------------------------- |
+| :------ | :--------------------------------------------------------------------------- |
 | default | Extra items on the opposite side of the header goes here, like button group. |
 
 ## ➤ How to use it

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.header",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.app-icon": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.app-icon": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/header.js"
 }

--- a/packages/components/help-text/CHANGELOG.md
+++ b/packages/components/help-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.help-text
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.help-text

--- a/packages/components/help-text/README.md
+++ b/packages/components/help-text/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | messages | messages | Array |  | List of message(s) |
 | title | title | String |  | If there are multiple messages, there should be a title for the help text |
 | size | size | String | sizes.FULL |  |
@@ -42,7 +42,7 @@
 ## ➤ Slots
 
 | Name     | Description                                           |
-| -------- | ----------------------------------------------------- |
+| :------- | :---------------------------------------------------- |
 | title    | You can use this slot to provide custom html as title |
 | messages | Customize message items                               |
 

--- a/packages/components/help-text/package.json
+++ b/packages/components/help-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.help-text",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/help-text.js"
 }

--- a/packages/components/help-text/src/help-text.js
+++ b/packages/components/help-text/src/help-text.js
@@ -63,7 +63,7 @@ export class TSHelpText extends TSElement {
 								<!-- You can use this slot to provide custom html as title -->
 								<slot name="title">${this.title}</slot>
 							</dt>
-					  `
+						`
 					: ''}
 				<!-- Customize message items -->
 				<slot name="messages">

--- a/packages/components/icon/CHANGELOG.md
+++ b/packages/components/icon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.icon
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/icon/README.md
+++ b/packages/components/icon/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property   | Attribute  | Type    | Default      | Description                                             |
-| ---------- | ---------- | ------- | ------------ | ------------------------------------------------------- |
+| :--------- | :--------- | :------ | :----------- | :------------------------------------------------------ |
 | icon       | icon       | String  |              | Icon name, ex: 'arrow-up' or inline svg string          |
 | src        | src        | String  |              | Url to svg for icon. It will override the icon property |
 | size       | size       | String  | sizes.MEDIUM | 'small' or 'medium' or 'large'                          |

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.icon",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -19,7 +19,7 @@
     "pre-build": "node ./scripts/export-svg.js"
   },
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/icon.js"
 }

--- a/packages/components/icon/stories/icon.stories.js
+++ b/packages/components/icon/stories/icon.stories.js
@@ -52,10 +52,11 @@ export const AllIcons = () => {
 		</style>
 		<div style="display: flex; flex-wrap: wrap; gap: var(--ts-unit-quarter);">
 			${iconList.map(
-				icon => html`<div class="block">
-					<ts-icon type="${type}" icon="${icon}" size="${size}"></ts-icon>
-					<span>${icon}</span>
-				</div>`
+				icon =>
+					html`<div class="block">
+						<ts-icon type="${type}" icon="${icon}" size="${size}"></ts-icon>
+						<span>${icon}</span>
+					</div>`
 			)}
 		</div>`;
 };

--- a/packages/components/input/CHANGELOG.md
+++ b/packages/components/input/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.input
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.input

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | hasError | hasError | Boolean | false | Show error style |
 | disabled | disabled | Boolean | false | Disable state of the input |
 | readonly | readonly | Boolean | false | Readonly state of the input |
@@ -42,7 +42,7 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | default | Put an input tag inside ts-input, so it's included in the light dom which let's the form to include its data in form data |
 
 ## ➤ How to use it

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.input",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/input.js"
 }

--- a/packages/components/label/CHANGELOG.md
+++ b/packages/components/label/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.label
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.label

--- a/packages/components/label/README.md
+++ b/packages/components/label/README.md
@@ -31,13 +31,13 @@
 ## ➤ Properties
 
 | Property | Attribute | Type   | Default | Description |
-| -------- | --------- | ------ | ------- | ----------- |
+| :------- | :-------- | :----- | :------ | :---------- |
 | for      | for       | String |         |             |
 
 ## ➤ Slots
 
 | Name    | Description |
-| ------- | ----------- |
+| :------ | :---------- |
 | default |             |
 
 ## ➤ How to use it

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.label",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/label.js"
 }

--- a/packages/components/list-item/CHANGELOG.md
+++ b/packages/components/list-item/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.list-item
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.list-item

--- a/packages/components/list-item/README.md
+++ b/packages/components/list-item/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property     | Attribute     | Type    | Default     | Description |
-| ------------ | ------------- | ------- | ----------- | ----------- |
+| :----------- | :------------ | :------ | :---------- | :---------- |
 | title        | title         | String  |             |             |
 | subtitle     | subtitle      | String  |             |             |
 | disabled     | disabled      | Boolean | false       |             |
@@ -47,7 +47,7 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | icon-left | In case you don't want to use "ts-icon"s as left icon, you can use this slot. Remember to remove icon attribute. |
 
 ## ➤ How to use it

--- a/packages/components/list-item/package.json
+++ b/packages/components/list-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.list-item",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.app-icon": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.typography": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.app-icon": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.typography": "^0.40.3"
   },
   "src": "src/list-item.js"
 }

--- a/packages/components/list-item/src/list-item.js
+++ b/packages/components/list-item/src/list-item.js
@@ -59,7 +59,7 @@ export class TSListItem extends TSElement {
 						<!--	In case you don't want to use "ts-icon"s as left icon, you can use this slot. Remember to remove icon attribute. -->
 						<slot name="icon-left" @slotchange="${this.slotChangeHandler}"></slot>
 					</span>
-			  `;
+				`;
 	}
 
 	get iconRightTemplate() {
@@ -88,7 +88,7 @@ export class TSListItem extends TSElement {
 								?no-wrap="${this.noWrap}"
 								no-tooltip
 							></ts-typography>
-					  `
+						`
 					: null}
 			</div>
 		`;

--- a/packages/components/modal/CHANGELOG.md
+++ b/packages/components/modal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.modal
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.modal

--- a/packages/components/modal/README.md
+++ b/packages/components/modal/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | data-dir | String | ltr | Direction 'rtl' or 'ltr' |
 | size | data-size | String | sizes.LARGE | Size of the modal. Available variants: 'large', 'medium', 'small' |
 | title | data-title | String | '' | Modal header text |
@@ -44,7 +44,7 @@
 ## ➤ Slots
 
 | Name   | Description                                                                      |
-| ------ | -------------------------------------------------------------------------------- |
+| :----- | :------------------------------------------------------------------------------- |
 | note   | Use this slot name on the \`ts-note\` in the modal                               |
 | main   | Content in the main section of the modal                                         |
 | footer | Content in the footer section of the modal, most of the time \`ts-button-group\` |
@@ -52,7 +52,7 @@
 ## ➤ Events
 
 | Name   | Description                                       | Payload |
-| ------ | ------------------------------------------------- | ------- |
+| :----- | :------------------------------------------------ | :------ |
 | close  | Emitted on start of the modal closing             |         |
 | opened | Emitted when the animation of opening is finished |         |
 | closed | Emitted when the animation of closing is finished |         |

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.modal",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,14 +15,14 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.button-group": "^0.40.2",
-    "@tradeshift/elements.card": "^0.40.2",
-    "@tradeshift/elements.cover": "^0.40.2",
-    "@tradeshift/elements.header": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.note": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.button-group": "^0.40.3",
+    "@tradeshift/elements.card": "^0.40.3",
+    "@tradeshift/elements.cover": "^0.40.3",
+    "@tradeshift/elements.header": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.note": "^0.40.3"
   },
   "src": "src/modal.js"
 }

--- a/packages/components/modal/src/modal.css
+++ b/packages/components/modal/src/modal.css
@@ -67,13 +67,17 @@ footer {
 .fade-in {
 	opacity: 1;
 	visibility: visible;
-	transition: visibility var(--ts-transition-now) linear var(--ts-transition-now), opacity var(--ts-transition-fast);
+	transition:
+		visibility var(--ts-transition-now) linear var(--ts-transition-now),
+		opacity var(--ts-transition-fast);
 }
 
 .fade-out {
 	opacity: 0;
 	visibility: hidden;
-	transition: visibility var(--ts-transition-fast) linear var(--ts-transition-now), opacity var(--ts-transition-fast);
+	transition:
+		visibility var(--ts-transition-fast) linear var(--ts-transition-now),
+		opacity var(--ts-transition-fast);
 }
 
 @media (max-width: env(--mobile-screen-breakpoint)) {

--- a/packages/components/note/CHANGELOG.md
+++ b/packages/components/note/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.note
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.note

--- a/packages/components/note/README.md
+++ b/packages/components/note/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property  | Attribute | Type    | Default | Description |
-| --------- | --------- | ------- | ------- | ----------- |
+| :-------- | :-------- | :------ | :------ | :---------- |
 | icon      | icon      | String  |         |             |
 | type      | type      | String  |         |             |
 | dir       | dir       | String  | ltr     |             |
@@ -42,13 +42,13 @@
 ## ➤ Slots
 
 | Name    | Description |
-| ------- | ----------- |
+| :------ | :---------- |
 | default |             |
 
 ## ➤ Events
 
 | Name         | Description |
-| ------------ | ----------- |
+| :----------- | :---------- |
 | close        |             |
 | button-click |             |
 

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.note",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/note.js"
 }

--- a/packages/components/note/src/note.js
+++ b/packages/components/note/src/note.js
@@ -89,7 +89,7 @@ export class TSNote extends TSElement {
 								size="large"
 								type="${this.iconType}"
 							></ts-icon>
-					  `
+						`
 					: ''}
 				<p class="${classNames.CONTENT}">
 					<slot></slot>

--- a/packages/components/overlay/CHANGELOG.md
+++ b/packages/components/overlay/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.overlay
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.overlay

--- a/packages/components/overlay/README.md
+++ b/packages/components/overlay/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | anchor | anchor | Object |  | The element where the container will be rendered. |
 | autoWidth | autoWidth | Boolean | false | Should the width be based on content (true) or inherited from the anchor (false). |
@@ -39,13 +39,13 @@
 ## ➤ Slots
 
 | Name    | Description                                            |
-| ------- | ------------------------------------------------------ |
+| :------ | :----------------------------------------------------- |
 | default | All content should be wrapped in one container element |
 
 ## ➤ Events
 
 | Name          | Description                                                          | Payload |
-| ------------- | -------------------------------------------------------------------- | ------- |
+| :------------ | :------------------------------------------------------------------- | :------ |
 | overlay-close | Emitted when user clicks outside of the overlay and anchor elements. |         |
 
 ## ➤ How to use it

--- a/packages/components/overlay/package.json
+++ b/packages/components/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.overlay",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/overlay.js"
 }

--- a/packages/components/pager/CHANGELOG.md
+++ b/packages/components/pager/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+### Bug Fixes
+
+- add perPageOptions property for customizable items per page ([f5a3e06](https://github.com/Tradeshift/elements/commit/f5a3e06d011043d99c34e0ef9ceaed6abe8dcc6d))
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/pager/package.json
+++ b/packages/components/pager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.pager",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,9 +15,9 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.tooltip": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.tooltip": "^0.40.3"
   },
   "src": "src/pager.js"
 }

--- a/packages/components/pager/src/pager.css
+++ b/packages/components/pager/src/pager.css
@@ -91,8 +91,12 @@ li {
 	background-color: var(--ts-color-white);
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='292.4' height='292.4'%3E%3Cpath fill='%23648897' d='M287 69.4a17.6 17.6 0 0 0-13-5.4H18.4c-5 0-9.3 1.8-12.9 5.4A17.6 17.6 0 0 0 0 82.2c0 5 1.8 9.3 5.4 12.9l128 127.9c3.6 3.6 7.8 5.4 12.8 5.4s9.2-1.8 12.8-5.4L287 95c3.5-3.5 5.4-7.8 5.4-12.8 0-5-1.9-9.2-5.5-12.8z'/%3E%3C/svg%3E");
 	background-repeat: no-repeat, repeat;
-	background-position: right 0.7em top 50%, 0 0;
-	background-size: 0.65em auto, 100%;
+	background-position:
+		right 0.7em top 50%,
+		0 0;
+	background-size:
+		0.65em auto,
+		100%;
 
 	&::-ms-expand {
 		display: none;

--- a/packages/components/pager/types/pager.d.ts
+++ b/packages/components/pager/types/pager.d.ts
@@ -29,7 +29,7 @@ export interface TSPager {
 	perPage?: number;
 
 	/**  Custom list of per-page options, overrides the default [10,20,30,40,50]  */
-	perPageOptions?: number[];
+	perPageOptions?: any[];
 
 	/**  Translated messages for the user locale  */
 	translations?: Record<string, unknown>;

--- a/packages/components/popover/CHANGELOG.md
+++ b/packages/components/popover/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.popover
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.popover

--- a/packages/components/popover/README.md
+++ b/packages/components/popover/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | opened | opened | Boolean | false | Is the popover visible or not |
 | placement | placement | String |  | Placement, relative to the anchor. Could be 'topLeft', 'topRight', 'bottomLeft', 'bottomRight' |
 | header | header | String |  | Text in the title |
@@ -42,14 +42,14 @@
 ## ➤ Slots
 
 | Name    | Description                                                                        |
-| ------- | ---------------------------------------------------------------------------------- |
+| :------ | :--------------------------------------------------------------------------------- |
 | content | Content in the main section of the popover                                         |
 | footer  | Content in the footer section of the popover, most of the time \`ts-button-group\` |
 
 ## ➤ Events
 
 | Name          | Description                                         | Payload |
-| ------------- | --------------------------------------------------- | ------- |
+| :------------ | :-------------------------------------------------- | :------ |
 | popover-close | Emitted when user press the close button in popover |         |
 
 ## ➤ How to use it

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.popover",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "src": "src/popover.js"
 }

--- a/packages/components/progress-bar/CHANGELOG.md
+++ b/packages/components/progress-bar/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.progress-bar
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/progress-bar/README.md
+++ b/packages/components/progress-bar/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property      | Attribute     | Type    | Default | Description |
-| ------------- | ------------- | ------- | ------- | ----------- |
+| :------------ | :------------ | :------ | :------ | :---------- |
 | total         | total         | Number  | 100     |             |
 | done          | done          | Number  | 0       |             |
 | indeterminate | indeterminate | Boolean | false   |             |

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.progress-bar",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/progress-bar.js"
 }

--- a/packages/components/radio-group/CHANGELOG.md
+++ b/packages/components/radio-group/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.radio-group
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/radio-group/README.md
+++ b/packages/components/radio-group/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type    | Default | Description                                   |
-| -------- | --------- | ------- | ------- | --------------------------------------------- |
+| :------- | :-------- | :------ | :------ | :-------------------------------------------- |
 | value    | value     | String  |         | Value of currently chosen ts-radio node       |
 | title    | title     | String  |         | Title of radio group                          |
 | index    | index     | Number  |         | Index of checked ts-radio node                |
@@ -41,13 +41,13 @@
 ## ➤ Slots
 
 | Name    | Description                                                                      |
-| ------- | -------------------------------------------------------------------------------- |
+| :------ | :------------------------------------------------------------------------------- |
 | default | All ts-radio elements should be wrapped by ts-radio-group to be grouped together |
 
 ## ➤ Events
 
 | Name           | Description                     | Payload                 |
-| -------------- | ------------------------------- | ----------------------- |
+| :------------- | :------------------------------ | :---------------------- |
 | radio-selected | Emitted on radio element select | { radio, index, value } |
 
 ## ➤ How to use it

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio-group",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.radio": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.radio": "^0.40.3"
   },
   "src": "src/radio-group.js"
 }

--- a/packages/components/radio/CHANGELOG.md
+++ b/packages/components/radio/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.radio
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.radio

--- a/packages/components/radio/README.md
+++ b/packages/components/radio/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type    | Default | Description        |
-| -------- | --------- | ------- | ------- | ------------------ |
+| :------- | :-------- | :------ | :------ | :----------------- |
 | value    | value     | String  |         | Value of the radio |
 | label    | label     | String  |         | Label of the radio |
 | checked  | checked   | Boolean | false   | Check status       |
@@ -40,7 +40,7 @@
 ## ➤ Events
 
 | Name        | Description |
-| ----------- | ----------- |
+| :---------- | :---------- |
 | radio-click |             |
 | radio-focus |             |
 | radio-blur  |             |

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.radio",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/radio.js"
 }

--- a/packages/components/root/CHANGELOG.md
+++ b/packages/components/root/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.root
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.root

--- a/packages/components/root/package.json
+++ b/packages/components/root/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.root",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.header": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.header": "^0.40.3"
   },
   "src": "src/root.js"
 }

--- a/packages/components/search/CHANGELOG.md
+++ b/packages/components/search/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.search
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/search/README.md
+++ b/packages/components/search/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | autofocus | autofocus | Boolean | false | Shoud the search be auto focused once page loaded |
 | dir | dir | String | ltr | Direction 'rtl' or 'ltr' |
 | focused | focused | Boolean | false | Set the focus on element |
@@ -47,7 +47,7 @@
 ## ➤ Events
 
 | Name | Description | Payload |
-| --- | --- | --- |
+| :-- | :-- | :-- |
 | idle | Emitted when the user not change input value for a provided timeout | search input value |
 | change | Emitted on every user's change in a search input or when user selects an item from the provided `dropdownItems` | search input value |
 | search | Emitted when the user press the 'Enter' key | search input value |

--- a/packages/components/search/package.json
+++ b/packages/components/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.search",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.overlay": "^0.40.2",
-    "@tradeshift/elements.select-menu": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.overlay": "^0.40.3",
+    "@tradeshift/elements.select-menu": "^0.40.3"
   },
   "src": "src/search.js"
 }

--- a/packages/components/select-menu/CHANGELOG.md
+++ b/packages/components/select-menu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.select-menu
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.select-menu

--- a/packages/components/select-menu/README.md
+++ b/packages/components/select-menu/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | items | items | Array |  | List of available options. Item must have 'id' and 'title', it can also have an 'icon' which is the name of the icon |
@@ -50,7 +50,7 @@
 ## ➤ Events
 
 | Name                | Description                                    | Payload |
-| ------------------- | ---------------------------------------------- | ------- |
+| :------------------ | :--------------------------------------------- | :------ |
 | select-menu-changed | Emitted when user applies the selected changes |         |
 
 ## ➤ How to use it

--- a/packages/components/select-menu/package.json
+++ b/packages/components/select-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select-menu",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,12 +15,12 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.button": "^0.40.2",
-    "@tradeshift/elements.button-group": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.list-item": "^0.40.2",
-    "@tradeshift/elements.spinner": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.button": "^0.40.3",
+    "@tradeshift/elements.button-group": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.list-item": "^0.40.3",
+    "@tradeshift/elements.spinner": "^0.40.3"
   },
   "src": "src/select-menu.js"
 }

--- a/packages/components/select-menu/src/select-menu.js
+++ b/packages/components/select-menu/src/select-menu.js
@@ -190,26 +190,27 @@ export class TSSelectMenu extends TSElement {
 			${this.loading
 				? html`<div class="loading-container">
 						<ts-spinner data-visible data-message="${this.translations.loading}" data-size="medium"></ts-spinner>
-				  </div>`
+					</div>`
 				: html`
 				<ul>
 					${
 						displayedItems.length > 0
 							? displayedItems.map(
-									item => html`<ts-list-item
-										class="items-list"
-										selectable
-										?disabled="${this.disabled}"
-										?selected="${this.currentSelection.indexOf(item.id) > -1}"
-										.item-id=${item.id}
-										dir="${this.dir}"
-										title="${item.title}"
-										icon="${item.icon || ''}"
-										icon-right="${this.multiselect ? checkboxIcon : ''}"
-										icon-selected="${checkboxOn}"
-										@click="${this.handleSelection}"
-									></ts-list-item>`
-							  )
+									item =>
+										html`<ts-list-item
+											class="items-list"
+											selectable
+											?disabled="${this.disabled}"
+											?selected="${this.currentSelection.indexOf(item.id) > -1}"
+											.item-id=${item.id}
+											dir="${this.dir}"
+											title="${item.title}"
+											icon="${item.icon || ''}"
+											icon-right="${this.multiselect ? checkboxIcon : ''}"
+											icon-selected="${checkboxOn}"
+											@click="${this.handleSelection}"
+										></ts-list-item>`
+								)
 							: html`<li class="no-items">${this.translations.no_items}</li>`
 					}
 				</ul>

--- a/packages/components/select/CHANGELOG.md
+++ b/packages/components/select/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.select
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.select

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Direction of the component 'rtl' or 'ltr'. |
 | disabled | disabled | Boolean | false | Is component disabled or not. |
 | opened | opened | Boolean | false | Is the dropdown part opened or not. |
@@ -60,13 +60,13 @@
 ## ➤ Slots
 
 | Name  | Description                                                     |
-| ----- | --------------------------------------------------------------- |
+| :---- | :-------------------------------------------------------------- |
 | label | If you want to have custom html in label, you can use this slot |
 
 ## ➤ Events
 
 | Name | Description | Payload |
-| --- | --- | --- |
+| :-- | :-- | :-- |
 | filter-value-change | Emitted when filter value of the select changes. You can listen to this for doing custom filtering and providing filteredItems to override the default component filtering. | { filterValue, id } |
 | select-changed | Emitted when user applies the selected changes | { selected, id } |
 

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.select",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,11 +15,11 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.help-text": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.overlay": "^0.40.2",
-    "@tradeshift/elements.select-menu": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.help-text": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.overlay": "^0.40.3",
+    "@tradeshift/elements.select-menu": "^0.40.3"
   },
   "src": "src/select.js"
 }

--- a/packages/components/select/src/select.js
+++ b/packages/components/select/src/select.js
@@ -341,7 +341,7 @@ export class TSSelect extends TSElement {
 								.caseSensitive="${this.caseSensitive}"
 								@select-menu-changed=${this.onChangeListener}
 							></ts-select-menu>
-					  </ts-overlay>`
+						</ts-overlay>`
 					: ''}
 			</div>
 		`;

--- a/packages/components/spinner/CHANGELOG.md
+++ b/packages/components/spinner/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.spinner
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.spinner

--- a/packages/components/spinner/README.md
+++ b/packages/components/spinner/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute    | Type    | Default     | Description                                     |
-| -------- | ------------ | ------- | ----------- | ----------------------------------------------- |
+| :------- | :----------- | :------ | :---------- | :---------------------------------------------- |
 | color    | data-color   | String  | colors.BLUE | Spinner color, `blue`, `mono`, `white`          |
 | message  | data-message | String  |             | Text to show below the spinner                  |
 | size     | data-size    | String  | sizes.LARGE | Size of the spinner, `large`, `medium`, `small` |

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.spinner",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/spinner.js"
 }

--- a/packages/components/status/CHANGELOG.md
+++ b/packages/components/status/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.status
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.status

--- a/packages/components/status/README.md
+++ b/packages/components/status/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type   | Default | Description |
-| -------- | --------- | ------ | ------- | ----------- |
+| :------- | :-------- | :----- | :------ | :---------- |
 | dir      | dir       | String | ltr     |             |
 | status   | status    | String | ''      |             |
 | text     | text      | String | ''      |             |

--- a/packages/components/status/package.json
+++ b/packages/components/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.status",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/status.js"
 }

--- a/packages/components/tab/CHANGELOG.md
+++ b/packages/components/tab/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.tab
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 ### Bug Fixes

--- a/packages/components/tab/README.md
+++ b/packages/components/tab/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | label | label | String |  | The label text for the header |
 | selected | selected | Boolean | false | Make the tab selected |
 | icon | icon | String |  | Icon name from the available icons in the ts-icon component |
@@ -41,13 +41,13 @@
 ## ➤ Slots
 
 | Name    | Description                                                |
-| ------- | ---------------------------------------------------------- |
+| :------ | :--------------------------------------------------------- |
 | default | Content of the tab should be wrapped in \`ts-tab\` element |
 
 ## ➤ Events
 
 | Name | Description | Payload |
-| --- | --- | --- |
+| :-- | :-- | :-- |
 | tab-prop-change | (Internal) Emitted when property of the tab is changed, it's used to let the ts-tabs know about the attribute changes. | {name} |
 
 ## ➤ How to use it

--- a/packages/components/tab/package.json
+++ b/packages/components/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tab",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/tab.js"
 }

--- a/packages/components/tabs/CHANGELOG.md
+++ b/packages/components/tabs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.tabs
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.tabs

--- a/packages/components/tabs/README.md
+++ b/packages/components/tabs/README.md
@@ -31,19 +31,19 @@
 ## ➤ Properties
 
 | Property | Attribute | Type   | Default | Description         |
-| -------- | --------- | ------ | ------- | ------------------- |
+| :------- | :-------- | :----- | :------ | :------------------ |
 | dir      | dir       | String | ltr     | Direction (rtl/ltr) |
 
 ## ➤ Slots
 
 | Name    | Description                                                                               |
-| ------- | ----------------------------------------------------------------------------------------- |
+| :------ | :---------------------------------------------------------------------------------------- |
 | default | All \`ts-tab\` elements should be wrapped with \`ts-tabs\` element to be grouped together |
 
 ## ➤ Events
 
 | Name      | Description |
-| --------- | ----------- |
+| :-------- | :---------- |
 | tab-click |             |
 
 ## ➤ How to use it

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tabs",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.tab": "^0.40.2",
-    "@tradeshift/elements.typography": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.tab": "^0.40.3",
+    "@tradeshift/elements.typography": "^0.40.3"
   },
   "src": "src/tabs.js"
 }

--- a/packages/components/tag/CHANGELOG.md
+++ b/packages/components/tag/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.tag
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.tag

--- a/packages/components/tag/README.md
+++ b/packages/components/tag/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | dir | dir | String | ltr | Text direction: 'rtl' or 'ltr' |
 | type | type | String |  | Type: success, warning, warning-lite, danger, blue, blue-lite. Affects background and foreground colors |
 | deletable | deletable | Boolean | false | Can the item be deleted? Displays a remove icon at the end of the tag |
@@ -44,7 +44,7 @@
 ## ➤ Events
 
 | Name       | Description                                                     | Payload |
-| ---------- | --------------------------------------------------------------- | ------- |
+| :--------- | :-------------------------------------------------------------- | :------ |
 | delete-tag | Emitted when the delete icon is clicked, if the tag is not busy | event   |
 | click-tag  | Emitted when the tag is clicked                                 | event   |
 

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tag",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,8 +15,8 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/text-field/CHANGELOG.md
+++ b/packages/components/text-field/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.text-field
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.text-field

--- a/packages/components/text-field/README.md
+++ b/packages/components/text-field/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type | Default | Description |
-| --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- |
 | label | label | String | '' | Label of the text field. If you need something more than simple string, use the label slot. |
 | id | id | String | 'input-id' | Id of the text field |
 | value | value | String | '' | Value of the text field |
@@ -54,14 +54,14 @@
 ## ➤ Slots
 
 | Name | Description |
-| --- | --- |
+| :-- | :-- |
 | label | If you want to have custom html in label, you can use this slot |
 | ts-input | If you want to have the input/textarea in the light DOM, for example, to be able to access it in the form data, you can pass the ts-input element with the input/textarea yourself. |
 
 ## ➤ Events
 
 | Name   | Description                              | Payload                      |
-| ------ | ---------------------------------------- | ---------------------------- |
+| :----- | :--------------------------------------- | :--------------------------- |
 | input  | Emitted onInput event of input/textarea  | { value, originalEvent }     |
 | change | Emitted onChange event of input/textarea | { value, id, originalEvent } |
 

--- a/packages/components/text-field/package.json
+++ b/packages/components/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.text-field",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,10 +15,10 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2",
-    "@tradeshift/elements.help-text": "^0.40.2",
-    "@tradeshift/elements.icon": "^0.40.2",
-    "@tradeshift/elements.input": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3",
+    "@tradeshift/elements.help-text": "^0.40.3",
+    "@tradeshift/elements.icon": "^0.40.3",
+    "@tradeshift/elements.input": "^0.40.3"
   },
   "src": "src/text-field.js"
 }

--- a/packages/components/text-field/src/text-field.js
+++ b/packages/components/text-field/src/text-field.js
@@ -155,7 +155,7 @@ export class TSTextField extends TSElement {
 									>
 ${this.value}</textarea
 									>
-							  `
+								`
 							: html`
 									<input
 										id=${this.id}
@@ -167,7 +167,7 @@ ${this.value}</textarea
 										@input=${this.onInput}
 										@change=${this.onChange}
 									/>
-							  `}
+								`}
 					</ts-input>
 				</slot>
 				${this.helpText}

--- a/packages/components/tooltip/CHANGELOG.md
+++ b/packages/components/tooltip/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.tooltip
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.tooltip

--- a/packages/components/tooltip/README.md
+++ b/packages/components/tooltip/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property | Attribute | Type    | Default       | Description                                      |
-| -------- | --------- | ------- | ------------- | ------------------------------------------------ |
+| :------- | :-------- | :------ | :------------ | :----------------------------------------------- |
 | tooltip  | tooltip   | String  | ''            | Text that should be shown in the tooltip popover |
 | position | position  | String  | 'right'       | 'top', 'bottom', 'right', 'left'                 |
 | width    | width     | String  | 'max-content' | Determining width of thee tooltip                |
@@ -40,7 +40,7 @@
 ## ➤ Slots
 
 | Name    | Description                                                  |
-| ------- | ------------------------------------------------------------ |
+| :------ | :----------------------------------------------------------- |
 | default | Elements that have tooltip should be wrapped with ts-tooltip |
 
 ## ➤ How to use it

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.tooltip",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/tooltip.js"
 }

--- a/packages/components/typography/CHANGELOG.md
+++ b/packages/components/typography/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+**Note:** Version bump only for package @tradeshift/elements.typography
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements.typography

--- a/packages/components/typography/README.md
+++ b/packages/components/typography/README.md
@@ -31,7 +31,7 @@
 ## ➤ Properties
 
 | Property  | Attribute  | Type    | Default | Description |
-| --------- | ---------- | ------- | ------- | ----------- |
+| :-------- | :--------- | :------ | :------ | :---------- |
 | text      | text       | String  |         |             |
 | tooltip   | tooltip    | String  |         |             |
 | variant   | variant    | String  |         |             |
@@ -43,7 +43,7 @@
 ## ➤ Slots
 
 | Name    | Description |
-| ------- | ----------- |
+| :------ | :---------- |
 | default |             |
 | default |             |
 

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements.typography",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",
@@ -15,7 +15,7 @@
     "types/*"
   ],
   "dependencies": {
-    "@tradeshift/elements": "^0.40.2"
+    "@tradeshift/elements": "^0.40.3"
   },
   "src": "src/typography.js"
 }

--- a/packages/components/typography/src/typography.js
+++ b/packages/components/typography/src/typography.js
@@ -30,12 +30,12 @@ export class TSTypography extends TSElement {
 					<div class="text-wrapper">
 						<slot>${this.text}</slot>
 					</div>
-			  `
+				`
 			: html`
 					<div class="text-wrapper" title="${this.tooltip || this.text}">
 						<slot @slotchange="${this.textChangeHandler}">${this.text}</slot>
 					</div>
-			  `;
+				`;
 	}
 }
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.40.3](https://github.com/Tradeshift/elements/compare/v0.40.2...v0.40.3) (2026-05-25)
+
+### Bug Fixes
+
+- **deps:** update dependency lit-element to ^2.5.1 ([#560](https://github.com/Tradeshift/elements/issues/560)) ([674959f](https://github.com/Tradeshift/elements/commit/674959fec02fe9d3e1de12574f6f23ed076e5ff6))
+- **deps:** update dependency lit-element to ^4.0.5 ([66fcf1b](https://github.com/Tradeshift/elements/commit/66fcf1bb7c64b15216d580fd47aad47701725c12))
+- **deps:** update dependency lit-element to ^4.0.6 ([927df09](https://github.com/Tradeshift/elements/commit/927df095c0d9629f16f674d356c0b8850635c916))
+- **deps:** update dependency lit-element to ^4.1.0 ([59c917c](https://github.com/Tradeshift/elements/commit/59c917ca46b24e98d38ceee21c3072f44b692dba))
+- **deps:** update dependency lit-element to ^4.2.0 ([62d3590](https://github.com/Tradeshift/elements/commit/62d359039980108dc82992edb4878c979f3c16b4))
+- **deps:** update dependency lit-element to ^4.2.1 ([f6aae99](https://github.com/Tradeshift/elements/commit/f6aae99671d3887abbba04d565b7e27e1fe97a8c))
+- **deps:** update dependency lit-element to ^4.2.2 ([34aca09](https://github.com/Tradeshift/elements/commit/34aca0942f4682f4da9724b46edade994783f184))
+- **deps:** update dependency lit-element to v4 ([#591](https://github.com/Tradeshift/elements/issues/591)) ([681aaad](https://github.com/Tradeshift/elements/commit/681aaad7692f6841d45f04582917491daf890612))
+
 ## [0.40.2](https://github.com/Tradeshift/elements/compare/v0.40.1...v0.40.2) (2022-11-03)
 
 **Note:** Version bump only for package @tradeshift/elements

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/elements",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tradeshift/elements.git",

--- a/packages/core/src/fonts.css
+++ b/packages/core/src/fonts.css
@@ -7,7 +7,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 300;
-	src: local('Open Sans Light'), local('OpenSans-Light'),
+	src:
+		local('Open Sans Light'),
+		local('OpenSans-Light'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.light.latin-ext.woff2) format('woff2');
 }
 /* woff2 - latin */
@@ -16,7 +18,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 300;
-	src: local('Open Sans Light'), local('OpenSans-Light'),
+	src:
+		local('Open Sans Light'),
+		local('OpenSans-Light'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.light.latin.woff2) format('woff2'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.light.latin.latin-ext.woff) format('woff');
 }
@@ -28,7 +32,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 400;
-	src: local('Open Sans Regular'), local('OpenSans-Regular'),
+	src:
+		local('Open Sans Regular'),
+		local('OpenSans-Regular'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.regular.latin-ext.woff2) format('woff2');
 }
 /* woff2 - latin */
@@ -37,7 +43,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 400;
-	src: local('Open Sans Regular'), local('OpenSans-Regular'),
+	src:
+		local('Open Sans Regular'),
+		local('OpenSans-Regular'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.regular.latin.woff2) format('woff2'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.regular.latin.latin-ext.woff) format('woff');
 }
@@ -49,7 +57,9 @@
 	font-family: 'Open Sans';
 	font-style: italic;
 	font-weight: 400;
-	src: local('Open Sans Italic'), local('OpenSans-Italic'),
+	src:
+		local('Open Sans Italic'),
+		local('OpenSans-Italic'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.italic.latin-ext.woff2) format('woff2');
 }
 /* woff2 - latin */
@@ -58,7 +68,9 @@
 	font-family: 'Open Sans';
 	font-style: italic;
 	font-weight: 400;
-	src: local('Open Sans Italic'), local('OpenSans-Italic'),
+	src:
+		local('Open Sans Italic'),
+		local('OpenSans-Italic'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.italic.latin.woff2) format('woff2'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.italic.latin.latin-ext.woff) format('woff');
 }
@@ -70,7 +82,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 600;
-	src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
+	src:
+		local('Open Sans SemiBold'),
+		local('OpenSans-SemiBold'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.semibold.latin-ext.woff2) format('woff2');
 	unicode-range: U+0100-024f, U+0259, U+1-1eff, U+2020, U+20a0-20ab, U+20ad-20cf, U+2113, U+2c60-2c7f, U+A720-A7FF;
 }
@@ -80,7 +94,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 600;
-	src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
+	src:
+		local('Open Sans SemiBold'),
+		local('OpenSans-SemiBold'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.semibold.latin.woff2) format('woff2'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.semibold.latin.latin-ext.woff) format('woff');
 }
@@ -92,7 +108,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 700;
-	src: local('Open Sans Bold'), local('OpenSans-Bold'),
+	src:
+		local('Open Sans Bold'),
+		local('OpenSans-Bold'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.bold.latin-ext.woff2) format('woff2');
 	unicode-range: U+0100-024f, U+0259, U+1-1eff, U+2020, U+20a0-20ab, U+20ad-20cf, U+2113, U+2c60-2c7f, U+A720-A7FF;
 }
@@ -102,7 +120,9 @@
 	font-family: 'Open Sans';
 	font-style: normal;
 	font-weight: 700;
-	src: local('Open Sans Bold'), local('OpenSans-Bold'),
+	src:
+		local('Open Sans Bold'),
+		local('OpenSans-Bold'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.bold.latin.woff2) format('woff2'),
 		url(//d5wfroyti11sa.cloudfront.net/prod/fonts/opensans/201902081238.bold.latin.latin-ext.woff) format('woff');
 }

--- a/packages/core/src/vars.css
+++ b/packages/core/src/vars.css
@@ -154,11 +154,11 @@
 	--ts-boxshadow-border-default: var(--ts-boxshadow-border-width) var(--ts-border-color-default);
 	--ts-boxshadow-border-error: var(--ts-boxshadow-border-width) var(--ts-border-color-error);
 	--ts-boxshadow-border-success: var(--ts-boxshadow-border-width) var(--ts-border-color-success);
-	--ts-boxshadow-border-focus: var(--ts-boxshadow-border-width) var(--ts-border-color-focus),
-		0 0 0 1px var(--ts-border-color-focus);
+	--ts-boxshadow-border-focus:
+		var(--ts-boxshadow-border-width) var(--ts-border-color-focus), 0 0 0 1px var(--ts-border-color-focus);
 	--ts-boxshadow-border-primary: var(--ts-boxshadow-border-width) var(--ts-border-color-primary);
-	--ts-boxshadow-border-hover: var(--ts-boxshadow-border-width) var(--ts-border-color-hover-inner),
-		0 0 0 1px var(--ts-border-color-hover-outer);
+	--ts-boxshadow-border-hover:
+		var(--ts-boxshadow-border-width) var(--ts-border-color-hover-inner), 0 0 0 1px var(--ts-border-color-hover-outer);
 	--ts-progress-bar-height: 8px;
 	--ts-box-width-small: 280px;
 	--ts-box-width-medium: 360px;

--- a/scripts/get-readme-template-data.js
+++ b/scripts/get-readme-template-data.js
@@ -1,4 +1,5 @@
-const tablemark = require('tablemark');
+const _tablemark = require('tablemark');
+const tablemark = _tablemark.default || _tablemark;
 const { compStateLogger, readComponentFile } = require('./helpers');
 
 module.exports = function (componentName) {

--- a/scripts/update-readme-files.js
+++ b/scripts/update-readme-files.js
@@ -1,4 +1,5 @@
-const nodePlop = require('node-plop');
+const _nodePlopModule = require('node-plop');
+const nodePlop = _nodePlopModule.default || _nodePlopModule;
 const updateDocSource = require('./from-src');
 const { getComponentNames, compStateLogger } = require('./helpers');
 const xa = require('xa');
@@ -11,8 +12,8 @@ const xa = require('xa');
 	});
 })();
 
-function updateReadmeFiles(componentName) {
-	const plop = nodePlop(`./plopfile.js`);
+async function updateReadmeFiles(componentName) {
+	const plop = await nodePlop(`./plopfile.js`);
 	const updateReadme = plop.getGenerator('readme');
 	updateReadme.runActions({ name: componentName }).then(results => {
 		if (results.failures.length) {


### PR DESCRIPTION
- fix: update module imports to support default exports
- fix: add perPageOptions property for customizable items per page
- fix: update node version to 22 in workflows