### PR TITLE
fix(ci): guard npm-publish job to skip unrelated PR comments

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,15 @@ on:
 
 jobs:
   npm-publish:
+    # Guard here (not just inside the reusable workflow) so the self-hosted
+    # runner job is never queued for unrelated PR comments (e.g. bot comments
+    # like the SonarQube quality gate report). Queuing it anyway trips the
+    # org's actions-autoscaler policy that blocks self-hosted runners on this
+    # public repo, showing a spurious "action_required" check.
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == 'npm publish' &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     uses: tradeshift/actions-workflow-npm/.github/workflows/comment-npm-publish.yml@v1
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Investigated the failed check at https://github.com/Tradeshift/elements/runs/95983990682 (`actions-autoscaler`, conclusion `action_required`: "self-hosted runners are not available on public repositories").
- Root cause: `.github/workflows/npm-publish.yml` listens to every `issue_comment` on a PR with no top-level filter. The reusable workflow it calls (`tradeshift/actions-workflow-npm/.github/workflows/comment-npm-publish.yml@v1`) hardcodes `runs-on: [self-hosted, ts-large-x64-docker-large]` and only skips via an internal job `if:` (comment body must be exactly `npm publish` from an OWNER/MEMBER). In this case a `ts-sonarqube[bot]` quality-gate comment on PR #835 triggered it. Since `elements` is a public repo, the org's actions-autoscaler policy blocks self-hosted runners here and cancels the job at queue time — before the internal `if:` can skip it — surfacing as a spurious failed check on unrelated comments.
- Fix: move the same guard to the calling job in this repo's workflow, so the reusable workflow (and its self-hosted-runner job) is never queued for comments that don't match, avoiding the autoscaler false-positive entirely.

## Test plan
- [ ] Comment something unrelated (e.g. a normal review comment) on a PR and confirm no `npm-publish` check is queued/red.
- [ ] Comment `npm publish` on a PR as an org member and confirm the publish job still runs as before.