### PR TITLE
fix: use a fresh UUID instead of run_id for preview publish versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,7 +65,7 @@ jobs:
           # See README.md for what '<empty>' vs '<name>' publish.
           COMMENT='${{ github.event.comment.body }}'
           PKG_ARG=$(echo "$COMMENT" | sed -E 's/^npm publish[[:space:]]*//')
-          echo "version=0.0.0-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          echo "version=0.0.0-$(uuidgen)" >> "$GITHUB_OUTPUT"
           if [ -z "$PKG_ARG" ]; then
             echo "pkg_dir=" >> "$GITHUB_OUTPUT"
             echo "target=all packages" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ We are using [lerna to publish](https://github.com/lerna/lerna/tree/main/command
 
 Comment on the PR to publish a temporary preview version to GitHub Packages (restricted to Tradeshift org members / the repo owner):
 
-- `npm publish` — builds and publishes **every** package with the same `0.0.0-<run id>` version, under the `pr-preview` dist-tag. Package dependencies between them (e.g. `@tradeshift/elements.header`'s dependency on `@tradeshift/elements.app-icon`) are automatically rewritten to match.
+- `npm publish` — builds and publishes **every** package with the same `0.0.0-<uuid>` version, under the `pr-preview` dist-tag. Package dependencies between them (e.g. `@tradeshift/elements.header`'s dependency on `@tradeshift/elements.app-icon`) are automatically rewritten to match.
 - `npm publish <name>` — publishes only that one package, e.g. `npm publish app-icon` (`npm publish core` or `npm publish elements` for `@tradeshift/elements` itself). Use this only when nothing that package depends on changed — it does not rewrite that package's own dependency ranges, so a change in a dependency won't be reflected unless that dependency is also published (with `npm publish` or its own `npm publish <name>`).
 - The bot replies with the exact `npm install ... --registry=https://npm.pkg.github.com` command(s) to try it out.
 


### PR DESCRIPTION
## Summary

`github.run_id` stays the same across re-runs of the same workflow run (only `github.run_attempt` changes). If a run reaches the publish step and succeeds, but a later step fails, re-running it recomputes the identical `0.0.0-<run_id>` version and collides with what the earlier attempt already published.

Observed for real on a `npm publish pager` run on #839/#840 today ([run 32344017177](https://github.com/Tradeshift/elements/actions/runs/32344017177), attempt 2 of 2) — attempt 1 happened to fail before reaching the publish step, so no collision occurred that time, but the risk is real for any run that fails later.

Switches to a UUID generated fresh via `uuidgen` on every execution, which has no such collision risk regardless of why or how many times the job is retried. `README.md` updated to match (`0.0.0-<run id>` → `0.0.0-<uuid>`).

## Test plan
- [x] YAML validity checked locally
- [x] `0.0.0-$(uuidgen)` produces valid semver (checked with the `semver` package)
- [ ] Not exercised end-to-end in Actions — same as prior PRs in this series, needs to land on `master` to be testable via a real `npm publish` comment